### PR TITLE
[#175873794] Node Github Release template

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Templates are meant to be included into a project pipeline. Please refer to [thi
 ## Available templates
 
 * [Rest Healthcheck](templates/rest-healthcheck)
+* [Node Github Release](templates/node-github-release)
 
 ## Contributing
 

--- a/templates/node-github-release/README.md
+++ b/templates/node-github-release/README.md
@@ -1,0 +1,45 @@
+# Node Github Release template
+
+Opinionate sequence of steps to mark a new release of a Nodejs project hosted on a Github repository. It does the following:
+
+1. checkout a given release branch (usually `master`)
+1. bump the version according to a given [SemVer](https://semver.org/) option (`major`, `minor` or `patch`)
+1. tag the repository with the new version number
+1. push changes and tags to the repository
+1. creates a Github release from the release tag
+
+Dependencies are installed using `yarn`. They are needed because the appliation may define some custom `preversion`, `version` and/or `postversion` scripts that may require some external package.
+
+## Usage
+
+```yaml
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: pagopa/azure-devops-templates
+      ref: refs/tags/v1
+
+jobs:
+- template: templates/node-github-release/template.yaml@templates 
+  parameters:
+    semver: 'minor' # or major or patch
+    gitEmail: 'janedoe@company.com'
+    gitUsername: 'JaneDoe'
+    gitHubConnection: 'company_gh_connection'
+    nodeVersion: '10.19.0'
+    pkg_cache_version_id: 'v1'
+    pkg_cache_folder: $(Pipeline.Workspace)/.yarn
+```
+
+## Parameters
+
+|param|description|default|
+|-|-|-|
+|semver|The rule to bump the version with||
+|gitEmail|The email of the Github user which authors the version bump commit ||
+|gitUsername|The username of the Github user which authors the version bump commit ||
+|gitHubConnection|The service connection used by the Azure Pipeline to connect to Github||
+|nodeVersion|The version of Node to use||
+|pkg_cache_version_id|Used by the package cache, identifies the cache version ||
+|pkg_cache_folder|Used by the package cache, the folder where cached package are persisted by the pipeline ||

--- a/templates/node-github-release/template.yaml
+++ b/templates/node-github-release/template.yaml
@@ -1,0 +1,103 @@
+# Node Github Relase steps
+# Mark a release on the project repository, with version bump and tag,
+# and publish a release on Github
+
+parameters:
+
+# Versioning parameters
+- name: 'semver'
+  type: string
+  values:
+  - major
+  - minor
+  - patch
+
+# This is the branch in which we will push the release tag.
+# It'll be master, but it can be overridden
+# Basically, this variable is used to enforce the fact that we use the very same branch in different steps
+- name: 'release_branch'
+  type: string
+  default: master
+
+# Github parameters
+- name: 'gitUsername'
+  type: string
+- name: 'gitEmail'
+  type: string
+- name: 'gitHubConnection'
+  type: string
+
+# Node runtime parameters
+- name: 'nodeVersion'
+  type: string
+- name: 'pkg_cache_version_id'
+  type: string
+- name: 'pkg_cache_folder'
+  type: string
+
+
+steps:
+- checkout: self
+  displayName: 'Checkout'
+  clean: true
+  persistCredentials: true
+
+# setup git author
+- script: |
+    git config --global user.email "${{ parameters.gitEmail }}" && git config --global user.name "${{ parameters.gitUsername }}"
+  displayName: 'Git setup' 
+
+# Without this step, changes would be applied to a detatched head
+- script: |
+    git checkout ${{ parameters.release_branch }}
+  displayName: 'Checkout release branch'
+      
+# setup Node runtime
+- task: UseNode@1
+  inputs:
+    version: '${{ parameters.node_version }}'
+  displayName: 'Set up Node.js'
+- task: Cache@2
+  inputs:
+    key: 'yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)" | yarn.lock'
+    restoreKeys: |
+      yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)"
+    path: '${{ parameters.pkg_cache_folder }}'
+  displayName: 'Cache yarn packages'
+- script: |
+    yarn install --frozen-lockfile --no-progress --non-interactive --network-concurrency 1
+  displayName: 'Install node modules'
+  
+# bump version
+- script: |
+    npm version ${{ parameters.semver }} -m "Bump version to %s [skip ci]"
+    NEXT_VERSION=$(node -p "require('./package.json').version")
+    RELEASE_TAG="v$NEXT_VERSION-RELEASE"
+    git tag $RELEASE_TAG
+  displayName: 'Version bump and tag'
+- script: |
+    NEXT_VERSION=$(node -p "require('./package.json').version")
+    HEAD_SHA=$(git rev-parse HEAD)
+    TITLE="Release $NEXT_VERSION"
+    TAG="v$NEXT_VERSION-RELEASE"
+    echo "##vso[task.setvariable variable=title]$TITLE"
+    echo "##vso[task.setvariable variable=sha]$HEAD_SHA"
+    echo "##vso[task.setvariable variable=tag]$TAG"
+  displayName: 'Set release variables'
+
+# push new version
+- script: |
+    git push origin ${{ parameters.release_branch }} && git push --tags
+  displayName: 'Push to the release branch'
+
+# create new releae
+- task: GitHubRelease@0
+  inputs:
+    gitHubConnection: ${{ parameters.gitHubConnection }}
+    repositoryName: $(Build.Repository.Name)
+    action: create
+    target: $(sha)
+    tagSource: manual
+    tag: $(tag)
+    title: $(title)
+    addChangelog: true


### PR DESCRIPTION
Add a new template which implements the sequence of steps to release a new version of a Nodejs application on Github.

Please look at [its README file](https://github.com/pagopa/azure-pipeline-templates/blob/41d011b6ccdd8bb9b4830f087966776275af5f5d/templates/node-github-release/README.md) for specifications and intended usage
