### PR TITLE
Test on multiple OS

### DIFF
--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -3,9 +3,11 @@
 #
 
 parameters:
-  testOnImages:
-    - 'ubuntu-latest'
-    - 'windows-2019'
+  - name: 'testOnImages'
+    type: 'object'
+    default:
+      - 'ubuntu-latest'
+      - 'windows-2019'
 
 # Automatically triggered on PR
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#pr-trigger

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -83,4 +83,5 @@ stages:
                 echo "Failed to install packages"
                 exit 1
               fi
+            workingDirectory: '.devops/__tests__/sample-node-app'
             displayName: 'Test'

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -74,8 +74,11 @@ stages:
               projectDir: '.devops/__tests__/sample-node-app'
           # test results    
           - bash: |
+              echo "current folder: $(pwd)"
               # a dummy package we expect to be installed
               expectedPackage="./node_modules/strings"
+              ls $expectedPackage && echo "package found" || echo "package not found"
+              node index.js && echo "test ok" || echo "test not ok"
               if [[ -d $expectedPackage ]]; then
                 echo "Node packages correctly installed"
                 exit 0

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -2,10 +2,10 @@
 # Each stage is dedicated to a template. Each job of a stage is a test.
 #
 
-variables:
+perameter:
   testOnImages:
-    'ubuntu-latest': true
-    'windows-2019': true
+    - 'ubuntu-latest'
+    - 'windows-2019'
 
 # Automatically triggered on PR
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#pr-trigger
@@ -17,14 +17,14 @@ pool:
   vmImage: 'ubuntu-latest'
 
 stages:
-  - ${{ each vm in variables.testOnImages }}:
-    - stage: Test_NodeJobSetup_${{ vm.Key }}
+  - ${{ each vm in perameters.testOnImages }}:
+    - stage: Test_NodeJobSetup_${{ vm }}
       dependsOn: []
       jobs:
         # Test that the job is setup with a provided Node version
         - job: test_provided_node_version
           pool:
-            vmImage: '${{ vm.Key }}'
+            vmImage: '${{ vm }}'
           steps:
           # use template  
           - template: ../templates/node-job-setup/template.yaml
@@ -45,7 +45,7 @@ stages:
         # Test that the job is setup and Node version is inferred from the app source
         - job: test_inferred_node_version   
           pool:
-            vmImage: '${{ vm.Key }}'   
+            vmImage: '${{ vm }}'   
           steps:
           # use template  
           - template: ../templates/node-job-setup/template.yaml
@@ -65,7 +65,7 @@ stages:
         # Test that packages are been installed
         - job: test_installed_packages
           pool:
-            vmImage: '${{ vm.Key }}'
+            vmImage: '${{ vm }}'
           steps:
           # use template  
           - template: ../templates/node-job-setup/template.yaml

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -3,7 +3,10 @@
 #
 
 parameters:
-  - name: 'testOnImages'
+  # A set of agents to execute test against.
+  #  Key is an arbitrary string (avoid using `-`)
+  #  Value is the name of the vm to test against
+  - name: 'vmToTestOn'
     type: 'object'
     default:
       linux: 'ubuntu-latest'
@@ -13,13 +16,9 @@ parameters:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#pr-trigger
 trigger: none
 
-# Execute agents (jobs) on latest Ubuntu version.
-# To change OS for a specific, ovverride "pool" attribute inside the job definition
-pool:
-  vmImage: 'ubuntu-latest'
-
 stages:
-  - ${{ each vm in parameters.testOnImages }}:
+  # Stages are applied on every VM we support, to ensure templates work well on each
+  - ${{ each vm in parameters.vmToTestOn }}:
     - stage: Test_NodeJobSetup_on_${{ vm.Key }}
       dependsOn: []
       jobs:

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -39,7 +39,7 @@ stages:
                 exit 0
               else 
                 echo "Wrong Node version set, received: $(node -v)"
-                exit 0
+                exit 1
               fi
             displayName: 'Test'
 
@@ -59,7 +59,7 @@ stages:
                 exit 0
               else 
                 echo "Wrong Node version set, received: $(node -v)"
-                exit 0
+                exit 1
               fi
             displayName: 'Test'
 
@@ -81,6 +81,6 @@ stages:
                 exit 0
               else 
                 echo "Failed to install packages"
-                exit 0
+                exit 1
               fi
             displayName: 'Test'

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -4,8 +4,8 @@
 
 variables:
   testOnImages:
-    - 'ubuntu-latest'
-    - 'windows-2019'
+    'ubuntu-latest': true
+    'windows-2019': true
 
 # Automatically triggered on PR
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#pr-trigger
@@ -18,13 +18,13 @@ pool:
 
 stages:
   - ${{ each vm in variables.testOnImages }}:
-    - stage: Test_NodeJobSetup_${{ vm }}
+    - stage: Test_NodeJobSetup_${{ vm.Key }}
       dependsOn: []
       jobs:
         # Test that the job is setup with a provided Node version
         - job: test_provided_node_version
           pool:
-            vmImage: '${{ vm }}'
+            vmImage: '${{ vm.Key }}'
           steps:
           # use template  
           - template: ../templates/node-job-setup/template.yaml
@@ -45,7 +45,7 @@ stages:
         # Test that the job is setup and Node version is inferred from the app source
         - job: test_inferred_node_version   
           pool:
-            vmImage: '${{ vm }}'   
+            vmImage: '${{ vm.Key }}'   
           steps:
           # use template  
           - template: ../templates/node-job-setup/template.yaml
@@ -65,7 +65,7 @@ stages:
         # Test that packages are been installed
         - job: test_installed_packages
           pool:
-            vmImage: '${{ vm }}'
+            vmImage: '${{ vm.Key }}'
           steps:
           # use template  
           - template: ../templates/node-job-setup/template.yaml

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -2,7 +2,7 @@
 # Each stage is dedicated to a template. Each job of a stage is a test.
 #
 
-perameter:
+parameters:
   testOnImages:
     - 'ubuntu-latest'
     - 'windows-2019'
@@ -17,7 +17,7 @@ pool:
   vmImage: 'ubuntu-latest'
 
 stages:
-  - ${{ each vm in perameters.testOnImages }}:
+  - ${{ each vm in parameters.testOnImages }}:
     - stage: Test_NodeJobSetup_${{ vm }}
       dependsOn: []
       jobs:

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -6,8 +6,8 @@ parameters:
   - name: 'testOnImages'
     type: 'object'
     default:
-      - 'ubuntu-latest'
-      - 'windows-2019'
+      linux: 'ubuntu-latest'
+      windows: 'windows-2019'
 
 # Automatically triggered on PR
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#pr-trigger
@@ -20,13 +20,13 @@ pool:
 
 stages:
   - ${{ each vm in parameters.testOnImages }}:
-    - stage: Test_NodeJobSetup
+    - stage: Test_NodeJobSetup${{ vm.Key }}
       dependsOn: []
       jobs:
         # Test that the job is setup with a provided Node version
         - job: test_provided_node_version
           pool:
-            vmImage: '${{ vm }}'
+            vmImage: '${{ vm.Value }}'
           steps:
           # use template  
           - template: ../templates/node-job-setup/template.yaml
@@ -47,7 +47,7 @@ stages:
         # Test that the job is setup and Node version is inferred from the app source
         - job: test_inferred_node_version   
           pool:
-            vmImage: '${{ vm }}'   
+            vmImage: '${{ vm.Value }}'   
           steps:
           # use template  
           - template: ../templates/node-job-setup/template.yaml
@@ -67,7 +67,7 @@ stages:
         # Test that packages are been installed
         - job: test_installed_packages
           pool:
-            vmImage: '${{ vm }}'
+            vmImage: '${{ vm.Value }}'
           steps:
           # use template  
           - template: ../templates/node-job-setup/template.yaml

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -20,7 +20,7 @@ pool:
 
 stages:
   - ${{ each vm in parameters.testOnImages }}:
-    - stage: Test_NodeJobSetup${{ vm.Key }}
+    - stage: Test_NodeJobSetup_on_${{ vm.Key }}
       dependsOn: []
       jobs:
         # Test that the job is setup with a provided Node version

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -76,9 +76,8 @@ stages:
           - bash: |
               echo "current folder: $(pwd)"
               # a dummy package we expect to be installed
-              expectedPackage="./node_modules/strings"
+              expectedPackage="./node_modules/stringz"
               ls $expectedPackage && echo "package found" || echo "package not found"
-              node index.js && echo "test ok" || echo "test not ok"
               if [[ -d $expectedPackage ]]; then
                 echo "Node packages correctly installed"
                 exit 0
@@ -86,5 +85,15 @@ stages:
                 echo "Failed to install packages"
                 exit 1
               fi
+              # run sample app
+              # if more extensive test
+              node index.js && echo "test ok" || echo "test not ok"
             workingDirectory: '.devops/__tests__/sample-node-app'
-            displayName: 'Test'
+            displayName: 'Test package are installed'
+          - bash: |
+              echo "current folder: $(pwd)"
+              # run sample app
+              # index.js runs a script that ensure the app is correctly set up 
+              node index.js
+            workingDirectory: '.devops/__tests__/sample-node-app'
+            displayName: 'Test sample app is working'

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -20,7 +20,7 @@ pool:
 
 stages:
   - ${{ each vm in parameters.testOnImages }}:
-    - stage: Test_NodeJobSetup_${{ vm }}
+    - stage: Test_NodeJobSetup
       dependsOn: []
       jobs:
         # Test that the job is setup with a provided Node version

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -34,7 +34,7 @@ stages:
               projectDir: '.devops/__tests__/sample-node-app'
               nodeVersion: '12.6.0'
           # test results    
-          - script: |
+          - bash: |
               if [[ $(node -v) = 'v12.6.0' ]]; then
                 echo "Node version correcly set"
                 exit 0
@@ -54,7 +54,7 @@ stages:
             parameters:
               projectDir: '.devops/__tests__/sample-node-app'
           # test results    
-          - script: |
+          - bash: |
               if [[ $(node -v) = 'v14.1.0' ]]; then
                 echo "Node version correcly set"
                 exit 0
@@ -74,7 +74,7 @@ stages:
             parameters:
               projectDir: '.devops/__tests__/sample-node-app'
           # test results    
-          - script: |
+          - bash: |
               # a dummy package we expect to be installed
               expectedPackage="./node_modules/strings"
               if [[ -d $expectedPackage ]]; then

--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -2,6 +2,10 @@
 # Each stage is dedicated to a template. Each job of a stage is a test.
 #
 
+variables:
+  testOnImages:
+    - 'ubuntu-latest'
+    - 'windows-2019'
 
 # Automatically triggered on PR
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#pr-trigger
@@ -13,62 +17,69 @@ pool:
   vmImage: 'ubuntu-latest'
 
 stages:
-  - stage: Test_NodeJobSetup
-    dependsOn: []
-    jobs:
-      # Test that the job is setup with a provided Node version
-      - job: test_provided_node_version      
-        steps:
-        # use template  
-        - template: ../templates/node-job-setup/template.yaml
-          parameters:
-            projectDir: '.devops/__tests__/sample-node-app'
-            nodeVersion: '12.6.0'
-        # test results    
-        - script: |
-            if [[ $(node -v) = 'v12.6.0' ]]; then
-              echo "Node version correcly set"
-              exit 0
-            else 
-              echo "Wrong Node version set, received: $(node -v)"
-              exit 0
-            fi
-          displayName: 'Test'
+  - ${{ each vm in variables.testOnImages }}:
+    - stage: Test_NodeJobSetup_${{ vm }}
+      dependsOn: []
+      jobs:
+        # Test that the job is setup with a provided Node version
+        - job: test_provided_node_version
+          pool:
+            vmImage: '${{ vm }}'
+          steps:
+          # use template  
+          - template: ../templates/node-job-setup/template.yaml
+            parameters:
+              projectDir: '.devops/__tests__/sample-node-app'
+              nodeVersion: '12.6.0'
+          # test results    
+          - script: |
+              if [[ $(node -v) = 'v12.6.0' ]]; then
+                echo "Node version correcly set"
+                exit 0
+              else 
+                echo "Wrong Node version set, received: $(node -v)"
+                exit 0
+              fi
+            displayName: 'Test'
 
-      # Test that the job is setup and Node version is inferred from the app source
-      - job: test_inferred_node_version      
-        steps:
-        # use template  
-        - template: ../templates/node-job-setup/template.yaml
-          parameters:
-            projectDir: '.devops/__tests__/sample-node-app'
-        # test results    
-        - script: |
-            if [[ $(node -v) = 'v14.1.0' ]]; then
-              echo "Node version correcly set"
-              exit 0
-            else 
-              echo "Wrong Node version set, received: $(node -v)"
-              exit 0
-            fi
-          displayName: 'Test'
+        # Test that the job is setup and Node version is inferred from the app source
+        - job: test_inferred_node_version   
+          pool:
+            vmImage: '${{ vm }}'   
+          steps:
+          # use template  
+          - template: ../templates/node-job-setup/template.yaml
+            parameters:
+              projectDir: '.devops/__tests__/sample-node-app'
+          # test results    
+          - script: |
+              if [[ $(node -v) = 'v14.1.0' ]]; then
+                echo "Node version correcly set"
+                exit 0
+              else 
+                echo "Wrong Node version set, received: $(node -v)"
+                exit 0
+              fi
+            displayName: 'Test'
 
-      # Test that packages are been installed
-      - job: test_installed_packages
-        steps:
-        # use template  
-        - template: ../templates/node-job-setup/template.yaml
-          parameters:
-            projectDir: '.devops/__tests__/sample-node-app'
-        # test results    
-        - script: |
-            # a dummy package we expect to be installed
-            expectedPackage="./node_modules/strings"
-            if [[ -d $expectedPackage ]]; then
-              echo "Node packages correctly installed"
-              exit 0
-            else 
-              echo "Failed to install packages"
-              exit 0
-            fi
-          displayName: 'Test'
+        # Test that packages are been installed
+        - job: test_installed_packages
+          pool:
+            vmImage: '${{ vm }}'
+          steps:
+          # use template  
+          - template: ../templates/node-job-setup/template.yaml
+            parameters:
+              projectDir: '.devops/__tests__/sample-node-app'
+          # test results    
+          - script: |
+              # a dummy package we expect to be installed
+              expectedPackage="./node_modules/strings"
+              if [[ -d $expectedPackage ]]; then
+                echo "Node packages correctly installed"
+                exit 0
+              else 
+                echo "Failed to install packages"
+                exit 0
+              fi
+            displayName: 'Test'

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Templates are meant to be included into a project pipeline. Please refer to [thi
   * an example snippet to describe usage
   * a full parameters table
 * Add an entry in the `Available templates` section of the repo main README (this file), with a link to the README of the template you just created.
+### Testing
+We have a [pipeline](.devops/test-pipelines.yaml) configured on this project to run test against the templates we produce. Although Azure Pipelines' DSL is not designed for a test-first approach, it's worth to try. Assets, mocks and scripts used for testings can be placed in [`.devops/__tests__`](.devops/__tests__) folder.
+
+Tests are configured to run on every Pull Request and there's no way ton run tests locally, so far. To use a _red-green-refactor_ approach, the best we can do is to work on a branch and open a draft PR on that.
 
 ### Release a new version
 New versions are created automatically on each merge on master branch. In the need of creating a release manually, use the `release.sh` script.

--- a/templates/node-job-setup/template.yaml
+++ b/templates/node-job-setup/template.yaml
@@ -51,6 +51,7 @@ steps:
       FROM_PARAM=${{ parameters.nodeVersion }}
       echo "set FROM_PARAM='$FROM_PARAM'"
       echo "##vso[task.setvariable variable=NODE_VERSION]$FROM_PARAM"
+    workingDirectory: ${{ parameters.projectDir }}
     displayName: 'Determine Node.js version from template param'
 - ${{ if eq(parameters.nodeVersion, 'none') }}:
   - bash: |
@@ -60,6 +61,7 @@ steps:
       ls .nvmrc && echo ".nvmrc found, value: '$(cat .nvmrc)'" || echo ".nvmrc not found" 
       echo "set FROM_SOURCE='$FROM_SOURCE'"
       echo "##vso[task.setvariable variable=NODE_VERSION]$FROM_SOURCE"
+    workingDirectory: ${{ parameters.projectDir }} 
     displayName: 'Determine Node.js version from source'
 
 - task: UseNode@1
@@ -70,4 +72,5 @@ steps:
 - bash: |
     echo "current folder: $(pwd)"
     yarn install --frozen-lockfile --no-progress --non-interactive --network-concurrency 1 
+  workingDirectory: ${{ parameters.projectDir }}    
   displayName: 'Install node modules'

--- a/templates/node-job-setup/template.yaml
+++ b/templates/node-job-setup/template.yaml
@@ -33,11 +33,11 @@ steps:
 # This is needed because the pipeline may point to a different commit than expected
 # The common case is when the previous stage pushed another commit
 - ${{ if ne(parameters.gitReference, 'none') }}:
-  - script: |
+  - bash: |
       git fetch && git checkout ${{ parameters.gitReference }}
     displayName: 'Checkout reference'  
 
-- script: |
+- bash: |
     cd ${{ parameters.projectDir }}
   displayName: 'Move to project folder'  
 
@@ -60,6 +60,6 @@ steps:
     version: $(NODE_VERSION)
   displayName: 'Set up Node.js'
 
-- script: |
+- bash: |
     yarn install --frozen-lockfile --no-progress --non-interactive --network-concurrency 1 
   displayName: 'Install node modules'

--- a/templates/node-job-setup/template.yaml
+++ b/templates/node-job-setup/template.yaml
@@ -45,12 +45,12 @@ steps:
 # Else, version is red from .node-version file
 # Else, version is red from .nvmrc file
 - ${{ if ne(parameters.nodeVersion, 'none') }}:
-  - script: |
+  - bash: |
       FROM_PARAM=${{ parameters.nodeVersion }}
       echo "##vso[task.setvariable variable=NODE_VERSION]$FROM_PARAM"
     displayName: 'Determine Node.js version from template param'
 - ${{ if eq(parameters.nodeVersion, 'none') }}:
-  - script: |
+  - bash: |
       FROM_SOURCE=$(cat .node-version || cat .nvmrc)
       echo "##vso[task.setvariable variable=NODE_VERSION]$FROM_SOURCE"
     displayName: 'Determine Node.js version from source'

--- a/templates/node-job-setup/template.yaml
+++ b/templates/node-job-setup/template.yaml
@@ -39,6 +39,7 @@ steps:
 
 - bash: |
     cd ${{ parameters.projectDir }}
+    echo "current folder: $(pwd)"
   displayName: 'Move to project folder'  
 
 # If a Node version is defined explicitly by parameter, such version is used
@@ -46,12 +47,14 @@ steps:
 # Else, version is red from .nvmrc file
 - ${{ if ne(parameters.nodeVersion, 'none') }}:
   - bash: |
+      echo "current folder: $(pwd)"
       FROM_PARAM=${{ parameters.nodeVersion }}
       echo "set FROM_PARAM='$FROM_PARAM'"
       echo "##vso[task.setvariable variable=NODE_VERSION]$FROM_PARAM"
     displayName: 'Determine Node.js version from template param'
 - ${{ if eq(parameters.nodeVersion, 'none') }}:
   - bash: |
+      echo "current folder: $(pwd)"
       FROM_SOURCE=$(cat .node-version || cat .nvmrc)
       ls .node-version && echo ".node-version found, value: '$(cat .node-version)'" || echo ".node-version not found" 
       ls .nvmrc && echo ".nvmrc found, value: '$(cat .nvmrc)'" || echo ".nvmrc not found" 
@@ -65,5 +68,6 @@ steps:
   displayName: 'Set up Node.js'
 
 - bash: |
+    echo "current folder: $(pwd)"
     yarn install --frozen-lockfile --no-progress --non-interactive --network-concurrency 1 
   displayName: 'Install node modules'

--- a/templates/node-job-setup/template.yaml
+++ b/templates/node-job-setup/template.yaml
@@ -47,11 +47,15 @@ steps:
 - ${{ if ne(parameters.nodeVersion, 'none') }}:
   - bash: |
       FROM_PARAM=${{ parameters.nodeVersion }}
+      echo "set FROM_PARAM='$FROM_PARAM'"
       echo "##vso[task.setvariable variable=NODE_VERSION]$FROM_PARAM"
     displayName: 'Determine Node.js version from template param'
 - ${{ if eq(parameters.nodeVersion, 'none') }}:
   - bash: |
       FROM_SOURCE=$(cat .node-version || cat .nvmrc)
+      ls .node-version && echo ".node-version found, value: '$(cat .node-version)'" || echo ".node-version not found" 
+      ls .nvmrc && echo ".nvmrc found, value: '$(cat .nvmrc)'" || echo ".nvmrc not found" 
+      echo "set FROM_SOURCE='$FROM_SOURCE'"
       echo "##vso[task.setvariable variable=NODE_VERSION]$FROM_SOURCE"
     displayName: 'Determine Node.js version from source'
 


### PR DESCRIPTION
Improve `node-job-setup` template to be compatible with Windows virtual agents. 
Basically, by using [script](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#script) task we were executing `Bash` on Linux and `cmd.exe` on Windows. We now use [bash](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#bash) task instead.

Also, this PR improves the test pipeline by performing tests in parallel on both Linux and Windows. 