### PR TITLE
[proposal] move to a base template for all 'io-functions-'project

### DIFF
--- a/.devops/baseTemplateTest/deploy-base-template.yml
+++ b/.devops/baseTemplateTest/deploy-base-template.yml
@@ -1,0 +1,210 @@
+# Azure DevOps Base pipeline to release a new version of 'io-funtions-xyz' and deploy to production.
+
+
+
+# -----------------------------------------
+
+parameters:  
+
+  - name: 'releaseSemVer'
+    displayName: 'When packing a release, define the version bump to apply'
+    type: string
+    values:
+      - major
+      - minor
+      - patch
+    default: minor
+
+  - name: 'nodeVersion'
+    type: string
+  - name: 'projectDir'
+    type: string
+    default: '.'
+
+  - name: 'gitEmail'
+    type: string
+  - name: 'gitUsername'
+    type: string
+  - name: 'gitHubConnection'
+    type: string
+
+  # - name: 'HEALTHCHECK_CONTAINER_RG'
+  #   type: string
+  # - name: 'HEALTHCHECK_CONTAINER_VNET'
+  #   type: string
+  # - name: 'HEALTHCHECK_CONTAINER_SUBNET'
+  #   type: string
+  # - name: 'HEALTHCHECK_PATH'
+  #   type: string
+
+# -----------------------------------------
+
+
+
+
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: pagopa/azure-pipeline-templates
+      ref: refs/tags/v7
+      endpoint: 'pagopa'
+
+
+stages:
+
+  # Create a relase
+  # Activated when ONE OF these are met:
+  # - is on branch master 
+  # - is a tag in the form v{version}-RELEASE
+  - stage: Release
+
+    variables:
+      # isMainBranch: $[ eq(variables['Build.SourceBranch'], 'refs/heads/master') ]
+      # isReleaseTag: $[ and(
+      #                   startsWith(variables['Build.SourceBranch'], 'refs/tags'),
+      #                   endsWith(variables['Build.SourceBranch'], '-RELEASE')
+      #                  ) ]
+     
+      isReleaseTag: true
+      isMainBranch: false
+
+    condition:
+      and(
+        succeeded(),
+        or(
+          eq(variables.isMainBranch, true),
+          eq(variables.isReleaseTag, true)
+          )
+      )
+    pool:
+      vmImage: 'ubuntu-latest'
+    jobs:
+
+      - job: make_release
+        condition: ${{ eq(variables.isMainBranch, true) }}
+        steps:
+        - checkout: self
+          persistCredentials: true
+        
+        - task: UseNode@1
+          inputs:
+            version: $(nodeVersion)
+          displayName: 'Set up Node.js'  
+
+        - template: fake-release-template.yml  
+          parameters:
+            semver: '${{ parameters.releaseSemVer }}'
+            gitEmail: $(gitEmail)
+            gitUsername: $(gitUsername)
+            gitHubConnection: $(gitHubConnection)
+            
+      - job: skip_release
+        condition: eq(variables.isReleaseTag, true)
+        steps:
+        - script: |
+            echo "We assume this reference to be a valid release: $(Build.SourceBranch). Therefore, there is no need to bundle a new release."
+          displayName: 'Skip release bundle'
+
+  # Prepare Artifact
+  - stage: Deploy_staging
+    dependsOn:
+      - Release
+    jobs:
+      - job: 'prepare_artifact_and_deploy'
+        steps:
+          # Build application
+          - template: templates/node-job-setup/template.yaml@templates 
+            parameters:
+              # On the assumption that this stage is executed only when Relase stage is,
+              #  with this parameter we set the reference the deploy script must pull changes from.
+              # The branch/tag name is calculated from the source branch
+              #  ex: Build.SourceBranch=refs/heads/master --> master
+              #  ex: Build.SourceBranch=refs/tags/v1.2.3-RELEASE --> v1.2.3-RELEASE
+              gitReference: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/tags/', ''), 'refs/heads/', '') }}
+              projectDir: ${{ parameters.projectDir }}
+          
+          - script: |
+              yarn predeploy
+            displayName: 'Build'
+
+          # Install functions extensions
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: "build"
+              arguments: "-o bin"
+
+          # Copy application to  
+          - task: CopyFiles@2
+            inputs:
+              SourceFolder: '$(System.DefaultWorkingDirectory)'
+              TargetFolder: '$(Build.ArtifactStagingDirectory)'
+              Contents: |
+                **/*
+                !.git/**/*
+                !**/*.js.map
+                !**/*.ts
+                !.vscode/**/*
+                !.devops/**/*
+                !.prettierrc
+                !.gitignore
+                !README.md
+                !jest.config.js
+                !local.settings.json
+                !test
+                !tsconfig.json
+                !tslint.json
+                !yarn.lock
+                !Dangerfile.js
+                !CODEOWNERS
+                !__*/**/*
+            displayName: 'Copy deploy files'
+            
+          - task: AzureFunctionApp@1  
+            inputs:
+              azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
+              resourceGroupName: '$(PRODUCTION_RESOURCE_GROUP_NAME)'
+              appType: 'functionApp'
+              appName: '$(PRODUCTION_APP_NAME)'
+              package: '$(Build.ArtifactStagingDirectory)/'
+              deploymentMethod: 'auto'
+              deployToSlotOrASE: true
+              slotName: 'staging'
+            displayName: Deploy to staging slot
+
+            # Check that the staging instance is healthy
+  
+  # Call Healthcheck endpoint to verify          
+  - stage: Healthcheck
+    dependsOn:
+      - Deploy_staging
+    jobs:
+      - job: 'do_healthcheck'       
+        steps:  
+          - template: templates/rest-healthcheck/template.yaml@pagopaCommons 
+            parameters:
+              azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
+              appName: '$(PRODUCTION_APP_NAME)'
+              endpoint: 'https://$(PRODUCTION_APP_NAME)-staging.azurewebsites.net/$(HEALTHCHECK_PATH)'
+              endpointType: 'private'
+              containerInstanceResourceGroup: '$(HEALTHCHECK_CONTAINER_RG)'
+              containerInstanceVNet: '$(HEALTHCHECK_CONTAINER_VNET)'
+              containerInstanceSubnet: '$(HEALTHCHECK_CONTAINER_SUBNET)'              
+
+  # Promote the staging instance to production
+  - stage: Deploy_production
+    dependsOn:
+      - Healthcheck
+      - Deploy_staging
+    jobs:
+      - job: 'do_deploy'       
+        steps:  
+          - task: AzureAppServiceManage@0   
+            inputs:
+              azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
+              resourceGroupName: '$(PRODUCTION_RESOURCE_GROUP_NAME)'
+              webAppName: '$(PRODUCTION_APP_NAME)'
+              sourceSlot: staging
+              swapWithProduction: true
+            displayName: Swap with production slot

--- a/.devops/baseTemplateTest/deploy-pipeline-test.yml
+++ b/.devops/baseTemplateTest/deploy-pipeline-test.yml
@@ -1,0 +1,32 @@
+# Azure DevOps pipeline to release a new version and deploy to production.
+
+variables:
+  nodeVersion: '10.14.1'
+
+parameters:
+  - name: 'releaseSemVer'
+    displayName: 'When packing a release, define the version bump to apply'
+    type: string
+    values:
+      - major
+      - minor
+      - patch
+    default: minor
+
+
+
+
+# Only manual activations are intended
+trigger: none
+pr: none
+
+
+extends:
+  template: deploy-base-template.yml
+  parameters:
+    nodeVersion: $(nodeVersion)
+    releaseSemVer: ${{ parameters.releaseSemVer }}
+    gitEmail: $(gitEmail)
+    gitUsername: $(gitUsername)
+    gitHubConnection: $(gitHubConnection)
+

--- a/.devops/baseTemplateTest/fake-release-template.yml
+++ b/.devops/baseTemplateTest/fake-release-template.yml
@@ -1,0 +1,74 @@
+# Node Github Relase steps
+# Mark a release on the project repository, with version bump and tag,
+# and publish a release on Github
+
+parameters:
+
+# Versioning parameters
+- name: 'semver'
+  type: string
+  values:
+  - major
+  - minor
+  - patch
+
+# This is the branch in which we will push the release tag.
+# It'll be master, but it can be overridden
+# Basically, this variable is used to enforce the fact that we use the very same branch in different steps
+- name: 'release_branch'
+  type: string
+  default: master
+
+# Github parameters
+- name: 'gitUsername'
+  type: string
+- name: 'gitEmail'
+  type: string
+- name: 'gitHubConnection'
+  type: string
+
+
+steps:
+# setup git author
+- script: |
+    git config --global user.email "${{ parameters.gitEmail }}" && git config --global user.name "${{ parameters.gitUsername }}"
+  displayName: 'Git setup' 
+
+# Without this step, changes would be applied to a detached head
+- script: |
+    git checkout ${{ parameters.release_branch }}
+  displayName: 'Checkout release branch'
+  
+# bump version
+- script: |
+    npm version ${{ parameters.semver }} -m "Bump version to %s [skip ci]"
+    NEXT_VERSION=$(node -p "require('./package.json').version")
+    RELEASE_TAG="v$NEXT_VERSION-RELEASE"
+    git tag $RELEASE_TAG
+  displayName: 'Version bump and tag'
+- script: |
+    NEXT_VERSION=$(node -p "require('./package.json').version")
+    HEAD_SHA=$(git rev-parse HEAD)
+    TITLE="Release $NEXT_VERSION"
+    TAG="v$NEXT_VERSION-RELEASE"
+    echo "##vso[task.setvariable variable=title]$TITLE"
+    echo "##vso[task.setvariable variable=sha]$HEAD_SHA"
+    echo "##vso[task.setvariable variable=tag]$TAG"
+  displayName: 'Set release variables'
+
+# # push new version
+# - script: |
+#     git push origin ${{ parameters.release_branch }} && git push --tags
+#   displayName: 'Push to the release branch'
+
+# # create new releae
+# - task: GitHubRelease@0
+#   inputs:
+#     gitHubConnection: ${{ parameters.gitHubConnection }}
+#     repositoryName: $(Build.Repository.Name)
+#     action: create
+#     target: $(sha)
+#     tagSource: manual
+#     tag: $(tag)
+#     title: $(title)
+#     addChangelog: true


### PR DESCRIPTION
This is a proposal PR to show the potentiality of having a base Azure Pipeline Template to extend within each _'io-functions- '_ project.

### Pros: 
- We won't anymore need to update every single deployment pipeline, we will just need to update the template and all the pipelines extending this template will inherit the new stages/steps/...
- We could add a list of steps to be called before and after each functionality (pre/after release, pre/afterdeploy, ..) so we can personalize each pipeline.

### Cons:
- We are moving complexity from within every single pipeline to a base one, so we'll need to maintain the consistency through time and projects