### PR TITLE
[#221686427] Generate SDK in different folders

### DIFF
--- a/templates/client-sdk-publish/template.yaml
+++ b/templates/client-sdk-publish/template.yaml
@@ -42,8 +42,8 @@ steps:
     echo "##vso[task.setvariable variable=codegenPackageNameParameter;]$PKG_NAME_PARAM"
     
     #Set generated code base directory
-    echo "setting generatedCodeDir=$(Agent.TempDirectory)/generated" 
-    echo "##vso[task.setvariable variable=generatedCodeDir;]$(Agent.TempDirectory)/generated"
+    echo "setting generatedCodeDir=$(Agent.TempDirectory)/generated_${{ parameters.artifactName }}" 
+    echo "##vso[task.setvariable variable=generatedCodeDir;]$(Agent.TempDirectory)/generated_${{ parameters.artifactName }}"
 
   name: setvarStep
   displayName: 'Setup conditional variables'


### PR DESCRIPTION
Enable the ability to generate multiple SDKs by handling different _'generatedCodeDir'_ based on _artifactName_ parameter