### PR TITLE
Use a specific version of the generator

### DIFF
--- a/templates/client-sdk-publish/README.md
+++ b/templates/client-sdk-publish/README.md
@@ -8,6 +8,10 @@ It does the following:
 1. generate package.json based on main package.json values (like name and version), using [@pagopa/openapi-codegen-ts](https://www.npmjs.com/package/@pagopa/openapi-codegen-ts)
 1. publish the package on NPM
 
+If the template is executed against a library/application that has [@pagopa/openapi-codegen-ts](https://www.npmjs.com/package/@pagopa/openapi-codegen-ts) as dependency, the specific version of such package is used; otherwise, the latest version will be fetched from registry. This mechanism supports `yarn` only, so far. 
+
+Please note that there's no need to install dependencies before the template, as no code from the application is executed.
+
 Be sure that this template is called **after** the main package.json has been updated.
 
 
@@ -46,8 +50,12 @@ stages:
 
 ## Parameters
 
-|param|description|default|required
+|param|description|default|required|
 |-|-|-|-|
 |openapiSpecPath|The relative path of the OpenAPI spec from projectDir folder | _To be defined_ |yes|
-|apiProjectDir|The project directory, in case of multi-project repo |'.'|no|
+|apiProjectDir|The project directory, in case of multi-project repo |`.`|no|
 |sdkPackageName|The name of the generated package| _Inherited from the api project's package.json_ |no|
+|generatorPackageName|Define the name of the generator package to be used. In most cases, there's no need do edit this parameter|`@pagopa/openapi-codegen-ts`|no|
+|npmRegistry|Define the url fo the registy to upload the package onto. In most cases, there's no need do edit this parameter|`https://registry.npmjs.org/`|no|
+|artifactName|The name of the artifact published in the pipeline space. The artifact is published to allow inspection, however the artifact name is overridable as it may be used in next steps or even jobs. In most cases, there's no need do edit this parameter|`Bundle_SDK`|no|
+

--- a/templates/client-sdk-publish/template.yaml
+++ b/templates/client-sdk-publish/template.yaml
@@ -13,6 +13,10 @@ parameters:
     type: string
     default: ''
 
+  - name: 'generatorPackageName'
+    type: string
+    default: '@pagopa/openapi-codegen-ts'
+
 # ------------------
 # Test parameters only
 
@@ -48,7 +52,13 @@ steps:
   name: setvarStep
   displayName: 'Setup conditional variables'
 - bash: |
-    npx -p @pagopa/openapi-codegen-ts gen-api-sdk --api-spec ${{ parameters.openapiSpecPath }} --out-dir $(generatedCodeDir) $(codegenPackageNameParameter) --client
+    set -euo pipefail
+    PACKAGE=${{ parameters.generatorPackageName }}
+    # If the application use a specific version of the generator package, use it; otherwise, just use latest version from the registry
+    # Warning: yarn only is supported
+    CODEGEN_VERSION=$(yarn list --depth=0 | grep $PACKAGE |  grep -Eo "([0-9]\.)+[0-9]+" || echo '*')
+    # Execute the generator fetching the specific pacakge from the registry
+    npx -p $PACKAGE@$CODEGEN_VERSION gen-api-sdk --api-spec ${{ parameters.openapiSpecPath }} --out-dir $(generatedCodeDir) $(codegenPackageNameParameter) --client
   displayName: 'Generate client and definitions'
   workingDirectory: ${{ parameters.apiProjectDir }}
 


### PR DESCRIPTION
This is an improvement over the `client-sdk-publish` template. The script tries to infer the version of `@pagopa/openapi-codegen-ts` used by the processed application, if it does; otherwise, it uses the latest available version.

In the most common scenario, the application that exposes the api generates definitions itself so it can use them as DTOs for its endpoints. By using the same version of the generator, we ensure such definitions are the very same we bundle on the sdk.

A `generatorPackageName` is added, too. This allow the user to override `@pagopa/openapi-codegen-ts` as the package used to generate the sdk. 

 


