### PR TITLE
moved yarnlock-file-upgrade test to master as mainBranch

### DIFF
--- a/.devops/test-pipelines.yaml
+++ b/.devops/test-pipelines.yaml
@@ -224,7 +224,6 @@ stages:
           parameters:
             projectDir: .devops/__tests__/sample-yarn-upgrade
             isTest: true
-            baseBranch: yarn-lockfile-upgrade-template
 
         - script: |
             #setup hub CLI
@@ -253,7 +252,6 @@ stages:
           parameters:
             projectDir: .devops/__tests__/sample-yarn-upgrade
             isTest: true
-            baseBranch: yarn-lockfile-upgrade-template
 
         - script: |
             #setup hub CLI


### PR DESCRIPTION
Since now we got yarn.lock file upgrade in master branch, we canpoint to master branch in tests