### PR TITLE
Remove yarn concurrency limit

### DIFF
--- a/templates/node-job-setup/template.yaml
+++ b/templates/node-job-setup/template.yaml
@@ -71,6 +71,6 @@ steps:
 
 - bash: |
     echo "current folder: $(pwd)"
-    yarn install --frozen-lockfile --no-progress --non-interactive --network-concurrency 1 
+    yarn install --frozen-lockfile --no-progress --non-interactive
   workingDirectory: ${{ parameters.projectDir }}    
   displayName: 'Install node modules'


### PR DESCRIPTION
I don't actually recall why we used to limit `yarn`'s request concurrency to 1. By removing such limit, I experienced 2x speed when installing packages to build an application in CI/CD.

Consider merge this PR