### PR TITLE
fix: Maven-github-release added all pom children to commit

### DIFF
--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -108,7 +108,7 @@ steps:
 
   # push new version
   - script: |
-      git add pom.xml
+      git add **/pom.xml
       git commit -m "Bump version [skip ci]"
       git push origin ${{ parameters.release_branch }}
     displayName: 'Push to the release branch'


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

<!-- markdownlint-disable-next-line -->
### List of changes

Adding all pom.xml when application include sub modules

### Motivation and context

The template now commit all the pom.xml children, to avoid problems

### Type of changes

- [ ] Add new template
- [X] Update template configuration
- [ ] Remove template
- [ ] Other changes

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
