### PR TITLE
feat: PAGOPA-601 customize helm version

### DIFF
--- a/templates/helm-microservice-chart-setup/template.yaml
+++ b/templates/helm-microservice-chart-setup/template.yaml
@@ -21,5 +21,5 @@ steps:
           yq -i ".appVersion = \"${DEPLOY_VERSION}\"" "$CHART_FILE"
         fi
         helm repo add microservice-chart https://pagopa.github.io/aks-microservice-chart-blueprint
-        helm dep upgrade helm
+        helm dep update helm
       failOnStderr: true

--- a/templates/helm-microservice-chart-setup/template.yaml
+++ b/templates/helm-microservice-chart-setup/template.yaml
@@ -21,5 +21,5 @@ steps:
           yq -i ".appVersion = \"${DEPLOY_VERSION}\"" "$CHART_FILE"
         fi
         helm repo add microservice-chart https://pagopa.github.io/aks-microservice-chart-blueprint
-        helm dep build helm
+        helm dep upgrade helm
       failOnStderr: true

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -81,28 +81,30 @@ steps:
         echo "##vso[task.setvariable variable=value;isOutput=true]$version"
       failOnStderr: true
 
-  - ${{ if and( eq(parameters.customHelmStep, 'none'), eq(parameters.skipHelmStep, 'false') ) }}:
-    - task: Bash@3
-      displayName: Update Version Helm
-      name: update_version_helm
-      inputs:
-        targetType: 'inline'
-        script: |
-          for i in helm/values-*.yaml; do
-            [ -f "$i" ] || break
-            yq -i ".microservice-chart.image.tag = \"$(next_version.value)\"" "$i"
-            git add "$i"
-          done
-          CHART_FILE="helm/Chart.yaml"
-          if [[ -f "$CHART_FILE" ]]; then
-            yq -i ".version = \"$(next_version.value)\"" "$CHART_FILE"
-            yq -i ".appVersion = \"$(next_version.value)\"" "$CHART_FILE"
-            git add "$CHART_FILE"
-          fi
+  - ${{ if eq(parameters.skipHelmStep, 'false') }}:
+    - ${{ if eq(parameters.customHelmStep, 'none') }}:
+      - task: Bash@3
+        displayName: Update Version Helm
+        name: update_version_helm
+        inputs:
+          targetType: 'inline'
+          script: |
+            for i in helm/values-*.yaml; do
+              [ -f "$i" ] || break
+              yq -i ".microservice-chart.image.tag = \"$(next_version.value)\"" "$i"
+              git add "$i"
+            done
+            CHART_FILE="helm/Chart.yaml"
+            if [[ -f "$CHART_FILE" ]]; then
+              yq -i ".version = \"$(next_version.value)\"" "$CHART_FILE"
+              yq -i ".appVersion = \"$(next_version.value)\"" "$CHART_FILE"
+              git add "$CHART_FILE"
+            fi
 
-  - ${{ if and ( ne(parameters.customHelmStep, 'none'), eq(parameters.skipHelmStep, 'false') ) }}:
-    - script: ${{ parameters.customHelmStep }}
-      displayName: 'Execute custom Helm script'
+#    - ${{ if ne(parameters.customHelmStep, 'none') }}:
+    - ${{ else }}:
+      - script: ${{ parameters.customHelmStep }}
+        displayName: 'Execute custom Helm script'
 
   - task: Bash@3
     displayName: Update Openapi/Swagger Version

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -33,7 +33,7 @@ parameters:
   # It replaces the standard Helm step in order to customize it according to the developer needs.
   - name: 'customHelmStep'
     type: string
-    default: 'None'
+    default: 'none'
 
 
 steps:
@@ -73,7 +73,7 @@ steps:
         echo "##vso[task.setvariable variable=value;isOutput=true]$version"
       failOnStderr: true
 
-  - ${{ if eq(parameters.customHelmStep, 'None') }}:
+  - ${{ if eq(parameters.customHelmStep, 'none') }}:
     - task: Bash@3
       displayName: Update Version Helm
       name: update_version_helm
@@ -92,7 +92,7 @@ steps:
             git add "$CHART_FILE"
           fi
 
-  - ${{ if ne(parameters.customHelmStep, 'None') }}:
+  - ${{ if ne(parameters.customHelmStep, 'none') }}:
     - script: ${{ parameters.customHelmStep }}
       displayName: 'Execute custom Helm script'
 

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -32,10 +32,10 @@ parameters:
   # Skip Helm step if it is not necessary to execute
   - name: 'skipHelmStep'
     type: boolean
-    default: False
+    default: false
     values:
-      - False
-      - True
+      - false
+      - true
 
   # Customize Helm step
   # It replaces the standard Helm step in order to customize it according to the developer needs.
@@ -81,7 +81,7 @@ steps:
         echo "##vso[task.setvariable variable=value;isOutput=true]$version"
       failOnStderr: true
 
-  - ${{ if and( eq(parameters.customHelmStep, 'none'), eq(parameters.skipHelmStep, 'False') ) }}:
+  - ${{ if and( eq(parameters.customHelmStep, 'none'), eq(parameters.skipHelmStep, 'false') ) }}:
     - task: Bash@3
       displayName: Update Version Helm
       name: update_version_helm
@@ -100,7 +100,7 @@ steps:
             git add "$CHART_FILE"
           fi
 
-  - ${{ if and ( ne(parameters.customHelmStep, 'none'), eq(parameters.skipHelmStep, 'False') ) }}:
+  - ${{ if and ( ne(parameters.customHelmStep, 'none'), eq(parameters.skipHelmStep, 'false') ) }}:
     - script: ${{ parameters.customHelmStep }}
       displayName: 'Execute custom Helm script'
 

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -75,18 +75,25 @@ steps:
 
   - script: |
       if [ "${{ parameters.customHelmStep }}" == "None" ]; then
-        USE_CUSTOM_HELM_SCRIPT='false'
+        USE_CUSTOM_HELM_SCRIPT="false"
       else
-        USE_CUSTOM_HELM_SCRIPT='true'
+        USE_CUSTOM_HELM_SCRIPT="true"
       fi
       echo "Use custom Helm scrip: ${USE_CUSTOM_HELM_SCRIPT}"
-      echo "##vso[task.setvariable variable=useCustomHelmScript]$USE_CUSTOM_HELM_SCRIPT"
-    displayName: "Set Helm step to execute"
+      echo "##vso[task.setvariable variable=useCustomHelmScript;isOutput=true]$USE_CUSTOM_HELM_SCRIPT"
+    displayName: 'Set Helm step to execute'
+    name: 'helmDefinition'
 
-  - script: ${{ variables.useCustomHelmScript }}
+  - script: $(variables.useCustomHelmScript)
     displayName: 'DEBUG evaluate helm step'
 
-  - ${{ if eq(variables.useCustomHelmScript, 'false') }}:
+  - script: $(useCustomHelmScript)
+    displayName: 'DEBUG 2 evaluate helm step'
+
+  - script: $(helmDefinition.useCustomHelmScript)
+    displayName: 'DEBUG 2 evaluate helm step'
+
+  - ${{ if eq($(useCustomHelmScript), 'false') }}:
     - task: Bash@3
       displayName: Update Version Helm
       name: update_version_helm
@@ -105,7 +112,7 @@ steps:
             git add "$CHART_FILE"
           fi
 
-  - ${{ if eq(variables.useCustomHelmScript, 'true') }}:
+  - ${{ if eq($(useCustomHelmScript), 'true') }}:
     - script: ${{ parameters.customHelmStep }}
       displayName: 'Execute custom Helm script'
 

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -81,7 +81,7 @@ steps:
         echo "##vso[task.setvariable variable=value;isOutput=true]$version"
       failOnStderr: true
 
-  - ${{ if eq(parameters.skipHelmStep, 'false') }}:
+  - ${{ if eq(parameters.skipHelmStep, false) }}:
     - ${{ if eq(parameters.customHelmStep, 'none') }}:
       - task: Bash@3
         displayName: Update Version Helm
@@ -101,7 +101,6 @@ steps:
               git add "$CHART_FILE"
             fi
 
-#    - ${{ if ne(parameters.customHelmStep, 'none') }}:
     - ${{ else }}:
       - script: ${{ parameters.customHelmStep }}
         displayName: 'Execute custom Helm script'

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -73,27 +73,7 @@ steps:
         echo "##vso[task.setvariable variable=value;isOutput=true]$version"
       failOnStderr: true
 
-  - script: |
-      if [ "${{ parameters.customHelmStep }}" == "None" ]; then
-        USE_CUSTOM_HELM_SCRIPT="false"
-      else
-        USE_CUSTOM_HELM_SCRIPT="true"
-      fi
-      echo "Use custom Helm scrip: ${USE_CUSTOM_HELM_SCRIPT}"
-      echo "##vso[task.setvariable variable=useCustomHelmScript;isOutput=true]$USE_CUSTOM_HELM_SCRIPT"
-    displayName: 'Set Helm step to execute'
-    name: 'helmDefinition'
-
-  - script: $(variables.useCustomHelmScript)
-    displayName: 'DEBUG evaluate helm step'
-
-  - script: $(useCustomHelmScript)
-    displayName: 'DEBUG 2 evaluate helm step'
-
-  - script: $(helmDefinition.useCustomHelmScript)
-    displayName: 'DEBUG 2 evaluate helm step'
-
-  - ${{ if eq(variables['useCustomHelmScript'], 'false') }}:
+  - ${{ if eq(parameters.customHelmStep, 'None') }}:
     - task: Bash@3
       displayName: Update Version Helm
       name: update_version_helm
@@ -112,7 +92,7 @@ steps:
             git add "$CHART_FILE"
           fi
 
-  - ${{ if eq(variables['useCustomHelmScript'], 'true') }}:
+  - ${{ if ne(parameters.customHelmStep, 'None') }}:
     - script: ${{ parameters.customHelmStep }}
       displayName: 'Execute custom Helm script'
 

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -93,7 +93,7 @@ steps:
   - script: $(helmDefinition.useCustomHelmScript)
     displayName: 'DEBUG 2 evaluate helm step'
 
-  - ${{ if eq(useCustomHelmScript, 'false') }}:
+  - ${{ if eq(variables['useCustomHelmScript'], 'false') }}:
     - task: Bash@3
       displayName: Update Version Helm
       name: update_version_helm
@@ -112,7 +112,7 @@ steps:
             git add "$CHART_FILE"
           fi
 
-  - ${{ if eq(useCustomHelmScript, 'true') }}:
+  - ${{ if eq(variables['useCustomHelmScript'], 'true') }}:
     - script: ${{ parameters.customHelmStep }}
       displayName: 'Execute custom Helm script'
 

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -29,6 +29,11 @@ parameters:
   - name: 'gitHubConnection'
     type: string
 
+  # Skip Helm step if it is not necessary to execute
+  - name: 'skipHelmStep'
+    type: boolean
+    default: false
+
   # Customize Helm step
   # It replaces the standard Helm step in order to customize it according to the developer needs.
   - name: 'customHelmStep'
@@ -73,7 +78,7 @@ steps:
         echo "##vso[task.setvariable variable=value;isOutput=true]$version"
       failOnStderr: true
 
-  - ${{ if eq(parameters.customHelmStep, 'none') }}:
+  - ${{ if and( eq(parameters.customHelmStep, 'none'), eq(parameters.skipHelmStep, false) ) }}:
     - task: Bash@3
       displayName: Update Version Helm
       name: update_version_helm
@@ -92,7 +97,7 @@ steps:
             git add "$CHART_FILE"
           fi
 
-  - ${{ if ne(parameters.customHelmStep, 'none') }}:
+  - ${{ if and ( ne(parameters.customHelmStep, 'none'), eq(parameters.skipHelmStep, false) ) }}:
     - script: ${{ parameters.customHelmStep }}
       displayName: 'Execute custom Helm script'
 

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -29,6 +29,18 @@ parameters:
   - name: 'gitHubConnection'
     type: string
 
+  # Customize Helm step
+  # It replaces the standard Helm step in order to customize it according to the developer needs.
+  - name: 'customHelmStep'
+    type: string
+    default: 'None'
+
+variables:
+  ${{ if eq(parameters['customHelmStep'], 'None') }}:
+    useCustomHelmScript: false
+  ${{ if ne(parameters['customHelmStep'], 'None') }}:
+    useCustomHelmScript: true
+
 steps:
   # setup git author
   - script: |
@@ -66,23 +78,28 @@ steps:
         echo "##vso[task.setvariable variable=value;isOutput=true]$version"
       failOnStderr: true
 
-  - task: Bash@3
-    displayName: Update Version Helm
-    name: update_version_helm
-    inputs:
-      targetType: 'inline'
-      script: |
-        for i in helm/values-*.yaml; do
-          [ -f "$i" ] || break
-          yq -i ".microservice-chart.image.tag = \"$(next_version.value)\"" "$i"
-          git add "$i"
-        done
-        CHART_FILE="helm/Chart.yaml"
-        if [[ -f "$CHART_FILE" ]]; then
-          yq -i ".version = \"$(next_version.value)\"" "$CHART_FILE"
-          yq -i ".appVersion = \"$(next_version.value)\"" "$CHART_FILE"
-          git add "$CHART_FILE"
-        fi
+  - ${{ if eq(variables.useCustomHelmScript, false) }}:
+    - task: Bash@3
+      displayName: Update Version Helm
+      name: update_version_helm
+      inputs:
+        targetType: 'inline'
+        script: |
+          for i in helm/values-*.yaml; do
+            [ -f "$i" ] || break
+            yq -i ".microservice-chart.image.tag = \"$(next_version.value)\"" "$i"
+            git add "$i"
+          done
+          CHART_FILE="helm/Chart.yaml"
+          if [[ -f "$CHART_FILE" ]]; then
+            yq -i ".version = \"$(next_version.value)\"" "$CHART_FILE"
+            yq -i ".appVersion = \"$(next_version.value)\"" "$CHART_FILE"
+            git add "$CHART_FILE"
+          fi
+
+  - ${{ if eq(variables.useCustomHelmScript, true) }}:
+    - script: ${{ parameters.customHelmStep }}
+      displayName: 'Execute custom Helm script'
 
 
   - task: Bash@3

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -32,7 +32,10 @@ parameters:
   # Skip Helm step if it is not necessary to execute
   - name: 'skipHelmStep'
     type: boolean
-    default: false
+    default: False
+    values:
+      - False
+      - True
 
   # Customize Helm step
   # It replaces the standard Helm step in order to customize it according to the developer needs.
@@ -78,7 +81,7 @@ steps:
         echo "##vso[task.setvariable variable=value;isOutput=true]$version"
       failOnStderr: true
 
-  - ${{ if and( eq(parameters.customHelmStep, 'none'), eq(parameters.skipHelmStep, false) ) }}:
+  - ${{ if and( eq(parameters.customHelmStep, 'none'), eq(parameters.skipHelmStep, 'False') ) }}:
     - task: Bash@3
       displayName: Update Version Helm
       name: update_version_helm
@@ -97,7 +100,7 @@ steps:
             git add "$CHART_FILE"
           fi
 
-  - ${{ if and ( ne(parameters.customHelmStep, 'none'), eq(parameters.skipHelmStep, false) ) }}:
+  - ${{ if and ( ne(parameters.customHelmStep, 'none'), eq(parameters.skipHelmStep, 'False') ) }}:
     - script: ${{ parameters.customHelmStep }}
       displayName: 'Execute custom Helm script'
 

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -35,11 +35,6 @@ parameters:
     type: string
     default: 'None'
 
-variables:
-  ${{ if eq(parameters['customHelmStep'], 'None') }}:
-    useCustomHelmScript: false
-  ${{ if ne(parameters['customHelmStep'], 'None') }}:
-    useCustomHelmScript: true
 
 steps:
   # setup git author
@@ -77,6 +72,16 @@ steps:
         version=$(mvn -f pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
         echo "##vso[task.setvariable variable=value;isOutput=true]$version"
       failOnStderr: true
+
+  - script: |
+      if [ "${{ parameters.customHelmStep }}" == "None" ]; then
+        USE_CUSTOM_HELM_SCRIPT='false'
+      else
+        USE_CUSTOM_HELM_SCRIPT='true'
+      fi
+      echo "Use custom Helm scrip: ${USE_CUSTOM_HELM_SCRIPT}"
+      echo "##vso[task.setvariable variable=useCustomHelmScript]$USE_CUSTOM_HELM_SCRIPT"
+    displayName: "Evaluate which Helm step to execute"
 
   - ${{ if eq(variables.useCustomHelmScript, false) }}:
     - task: Bash@3

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -93,7 +93,7 @@ steps:
   - script: $(helmDefinition.useCustomHelmScript)
     displayName: 'DEBUG 2 evaluate helm step'
 
-  - ${{ if eq($(useCustomHelmScript), 'false') }}:
+  - ${{ if eq(useCustomHelmScript, 'false') }}:
     - task: Bash@3
       displayName: Update Version Helm
       name: update_version_helm
@@ -112,7 +112,7 @@ steps:
             git add "$CHART_FILE"
           fi
 
-  - ${{ if eq($(useCustomHelmScript), 'true') }}:
+  - ${{ if eq(useCustomHelmScript, 'true') }}:
     - script: ${{ parameters.customHelmStep }}
       displayName: 'Execute custom Helm script'
 

--- a/templates/maven-github-release/template.yaml
+++ b/templates/maven-github-release/template.yaml
@@ -81,9 +81,12 @@ steps:
       fi
       echo "Use custom Helm scrip: ${USE_CUSTOM_HELM_SCRIPT}"
       echo "##vso[task.setvariable variable=useCustomHelmScript]$USE_CUSTOM_HELM_SCRIPT"
-    displayName: "Evaluate which Helm step to execute"
+    displayName: "Set Helm step to execute"
 
-  - ${{ if eq(variables.useCustomHelmScript, false) }}:
+  - script: ${{ variables.useCustomHelmScript }}
+    displayName: 'DEBUG evaluate helm step'
+
+  - ${{ if eq(variables.useCustomHelmScript, 'false') }}:
     - task: Bash@3
       displayName: Update Version Helm
       name: update_version_helm
@@ -102,10 +105,9 @@ steps:
             git add "$CHART_FILE"
           fi
 
-  - ${{ if eq(variables.useCustomHelmScript, true) }}:
+  - ${{ if eq(variables.useCustomHelmScript, 'true') }}:
     - script: ${{ parameters.customHelmStep }}
       displayName: 'Execute custom Helm script'
-
 
   - task: Bash@3
     displayName: Update Openapi/Swagger Version


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

<!-- markdownlint-disable-next-line -->
### List of changes
- `maven-github-release`
  - customize helm step according to developer needs
- `helm-microservice-chart-setup`
  - replace build to update to avoid chart lock out of sync ([example](https://dev.azure.com/pagopaspa/pagoPA-projects/_build/results?buildId=80282&view=logs&j=845195f5-6388-51b2-d3f0-92c8cacc2296&t=06855775-f6af-59f7-f943-fcee45c05e84&l=68))

<!--- Describe your changes in detail -->

### Motivation and context
I don't want to set always `.microservice-chart.image.tag`, expecially when I want deploy a canary version.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new template
- [x] Update template configuration
- [ ] Remove template
- [ ] Other changes

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
