### PR TITLE
breaking: Terraform plan and apply without locks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+## v5.0.0
+
+- terraform-plan: now don't lock the state, so is more fast and can be cancelled
+- terraform-apply: use an internal plan that generate the state output file and allow to apply only the changed. No more locks needed
+- azure-kubeconfig-genator: allow to generate the kubeconfig with kubelogin

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,3 +5,4 @@
 - terraform-plan: now don't lock the state, so is more fast and can be cancelled
 - terraform-apply: use an internal plan that generate the state output file and allow to apply only the changed. No more locks needed
 - azure-kubeconfig-genator: allow to generate the kubeconfig with kubelogin
+- terraform-plan-apply: allow to use a separated service connection, one for plan (with low permissions) and the other with full permissions but with and env linked

--- a/templates/azure-kubeconfig-generator/README.md
+++ b/templates/azure-kubeconfig-generator/README.md
@@ -13,7 +13,6 @@ for kubernetes plans:
 ## Usage
 
 ```yaml
-steps:
   - template: ../azure-kubeconfig-generator/template.yaml
     parameters:
       AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'

--- a/templates/azure-kubeconfig-generator/template.yaml
+++ b/templates/azure-kubeconfig-generator/template.yaml
@@ -27,6 +27,7 @@ parameters:
 steps:
   - task: Bash@3
     displayName: Check Parameters for kubeconfig
+    condition: and(succeeded(), ne('${{ parameters.AKS_AZURE_DEVOPS_SA_CA_CRT }}', ''))
     inputs:
       targetType: inline
       failOnStderr: true

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -55,19 +55,13 @@ steps:
         export ARM_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
         export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
 
-        echo "before IF"
+        echo "[INFO] before IF"
         if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
           echo "[INFO] 🚀 Run terraform plan + kubernetes -> generate state"
-          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
-            -lock-timeout=3000s \
-            -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} \
-            -input=false"
+          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false"
         else
           echo "[INFO] 🚀 Run terraform plan -> generate state"
-          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
-            -lock-timeout=3000s \
-            -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} \
-            -input=false
+          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false
         fi
         echo "✅ State output generated"
 
@@ -91,19 +85,10 @@ steps:
 
         if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
           echo "[INFO] 🚀 Run terraform plan + kubernetes"
-          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
-            -var k8s_kube_config_path_prefix="$(pwd)"  \
-            -lock-timeout=3000s \
-            -auto-approve \
-            -input=false \
-            tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
+          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} -var k8s_kube_config_path_prefix="$(pwd)" -lock-timeout=3000s -auto-approve -input=false tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
         else
           echo "[INFO] 🚀 Run terraform plan"
-          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
-            -lock-timeout=3000s \
-            -auto-approve \
-            -input=false \
-            tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
+          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -auto-approve -input=false tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
         fi
 
   - task: AzureCLI@2

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -28,6 +28,7 @@ parameters:
     default: ""
 
 steps:
+  - checkout: self
   - template: ../azure-kubeconfig-generator/template.yaml
     parameters:
       AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
@@ -47,7 +48,7 @@ steps:
       failOnStandardError: true
       workingDirectory: '${{ parameters.WORKINGDIR }}'
       inlineScript: |
-        echo "##[section] 💈 Start terraform apply with tf-env-folder=${{ parameters.TF_ENVIRONMENT_FOLDER }}"
+        echo "##[section] 💈 Start terraform plan to generate state with tf-env-folder=${{ parameters.TF_ENVIRONMENT_FOLDER }}"
 
         echo "[INFO] Terraform setup variables"
         export ARM_CLIENT_ID="${servicePrincipalId}"

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -56,13 +56,13 @@ steps:
         export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
 
         echo "[INFO] before IF"
-        if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
-          echo "[INFO] 🚀 Run terraform plan + kubernetes -> generate state"
-          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false"
-        else
-          echo "[INFO] 🚀 Run terraform plan -> generate state"
-          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false
-        fi
+#        if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
+#          echo "[INFO] 🚀 Run terraform plan + kubernetes -> generate state"
+#          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false"
+#        else
+#          echo "[INFO] 🚀 Run terraform plan -> generate state"
+#          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false
+#        fi
         echo "✅ State output generated"
 
   - task: AzureCLI@2

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -28,44 +28,48 @@ parameters:
     default: ""
 
 steps:
-  - task: Bash@3
-    displayName: Apply(Check Parameters)
+  - template: ../azure-kubeconfig-generator/template.yaml
+    condition: and(succeeded(), ne('${{ parameters.AKS_AZURE_DEVOPS_SA_CA_CRT }}', ''))
+    parameters:
+      AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
+      WORKINGDIR: '${{ parameters.WORKINGDIR }}'
+      AKS_NAME: '${{ parameters.AKS_NAME }}'
+      AKS_API_SERVER_URL: '${{ parameters.AKS_API_SERVER_URL }}'
+      AKS_AZURE_DEVOPS_SA_CA_CRT: '${{ parameters.AKS_AZURE_DEVOPS_SA_CA_CRT }}'
+      AKS_AZURE_DEVOPS_SA_TOKEN: '${{ parameters.AKS_AZURE_DEVOPS_SA_TOKEN }}'
+
+  - task: AzureCLI@2
+    displayName: Plan(generate state)
     inputs:
-      targetType: inline
-      failOnStderr: true
-      script: |
-        set -e
-        e=0
+      azureSubscription: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
+      addSpnToEnvironment: true
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      failOnStandardError: true
+      workingDirectory: '${{ parameters.WORKINGDIR }}'
+      inlineScript: |
+        echo "##[section] 💈 Start terraform apply with tf-env-folder=${{ parameters.TF_ENVIRONMENT_FOLDER }}"
 
-        if [[ "${{ parameters.AKS_NAME }}" != "" ]] || \
-           [[ "${{ parameters.AKS_API_SERVER_URL }}" != "" ]] || \
-           [[ "${{ parameters.AKS_AZURE_DEVOPS_SA_TOKEN }}" != "" ]] || \
-           [[ "${{ parameters.AKS_AZURE_DEVOPS_SA_CA_CRT }}" != "" ]]; then
+        echo "[INFO] Terraform setup variables"
+        export ARM_CLIENT_ID="${servicePrincipalId}"
+        export ARM_CLIENT_SECRET="${servicePrincipalKey}"
+        export ARM_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
+        export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
 
-          if [[ "${{ parameters.AKS_NAME }}" == "" ]]; then
-            echo "##[error] AKS_NAME is empty"
-            ((e=e+1))
-          fi
-
-          if [[ "${{ parameters.AKS_API_SERVER_URL }}" == "" ]]; then
-            echo "##[error] AKS_API_SERVER_URL is empty"
-            ((e=e+1))
-          fi
-
-          if [[ "${{ parameters.AKS_AZURE_DEVOPS_SA_TOKEN }}" == "" ]]; then
-            echo "##[error] AKS_AZURE_DEVOPS_SA_TOKEN is empty"
-            ((e=e+1))
-          fi
-
-          if [[ "${{ parameters.AKS_AZURE_DEVOPS_SA_CA_CRT }}" == "" ]]; then
-            echo "##[error] AKS_AZURE_DEVOPS_SA_CA_CRT is empty"
-            ((e=e+1))
-          fi
-
-          if [[ $e > 0 ]]; then
-            exit 1
-          fi
+        if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
+          echo "[INFO] 🚀 Run terraform plan + kubernetes & generate state"
+          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
+            -lock-timeout=3000s \
+            -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} \
+            -input=false"
+        else
+          echo "[INFO] 🚀 Run terraform plan & generate state"
+          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
+            -lock-timeout=3000s \
+            -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} \
+            -input=false
         fi
+        echo "✅ State output generated"
 
   - task: AzureCLI@2
     displayName: Apply Terraform
@@ -77,7 +81,7 @@ steps:
       failOnStandardError: true
       workingDirectory: '${{ parameters.WORKINGDIR }}'
       inlineScript: |
-        echo "##[section] 💈 Start terraform apply for tf-env-folder=${{ parameters.TF_ENVIRONMENT_FOLDER }}"
+        echo "##[section] 💈 Start terraform apply with tf-env-folder=${{ parameters.TF_ENVIRONMENT_FOLDER }}"
 
         echo "[INFO] Terraform setup variables"
         export ARM_CLIENT_ID="${servicePrincipalId}"
@@ -85,45 +89,36 @@ steps:
         export ARM_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
         export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
 
-        if [[ "${{ parameters.AKS_AZURE_DEVOPS_SA_CA_CRT }}" != "" ]]; then
-
-          echo "##[group]Kubernetes kubeconfig setup"
-          echo "[INFO] Create cacrt file"
-          echo "${{ parameters.AKS_AZURE_DEVOPS_SA_CA_CRT }}"| base64 --decode > cacrt
-
-          echo "[INFO] kubectl config set-cluster"
-          kubectl config set-cluster aks-azure-devops \
-            --certificate-authority=cacrt \
-            --embed-certs=true \
-            --server=${{ parameters.AKS_API_SERVER_URL }} \
-            --kubeconfig="config-${{ parameters.AKS_NAME }}"
-
-          echo "[INFO] kubectl config set-credentials"
-          kubectl config set-credentials azure-devops \
-            --token=${{ parameters.AKS_AZURE_DEVOPS_SA_TOKEN }} \
-            --kubeconfig="config-${{ parameters.AKS_NAME }}"
-
-          echo "[INFO] kubectl config set-context"
-          kubectl config set-context iac \
-            --cluster=aks-azure-devops \
-            --user=azure-devops \
-            --kubeconfig="config-${{ parameters.AKS_NAME }}"
-
-          echo "[INFO] kubectl config use-context"
-          kubectl config use-context iac --kubeconfig="config-${{ parameters.AKS_NAME }}"
-
-          echo "##[endgroup]"
-        fi
-
         if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
           echo "[INFO] 🚀 Run terraform plan + kubernetes"
-          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} -auto-approve -var k8s_kube_config_path_prefix="$(pwd)"
+          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
+            -var k8s_kube_config_path_prefix="$(pwd)"  \
+            -lock-timeout=3000s \
+            -auto-approve \
+            -input=false \
+            tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
         else
           echo "[INFO] 🚀 Run terraform plan"
-          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} -auto-approve
+          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
+            -lock-timeout=3000s \
+            -auto-approve \
+            -input=false \
+            tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
         fi
 
+  - task: AzureCLI@2
+    displayName: Clean project
+    condition: always()
+    inputs:
+      azureSubscription: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
+      addSpnToEnvironment: true
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      failOnStandardError: true
+      workingDirectory: '${{ parameters.WORKINGDIR }}'
+      inlineScript: |
         echo "[INFO] Clean project"
         rm -rf .kube
         rm -rf .azure
         rm -rf config-${{ parameters.AKS_NAME }}
+        rm -f tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -88,13 +88,8 @@ steps:
           exit 1
         fi
         
-        ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
-          -lock-timeout=3000s \
-          -auto-approve \
-          -input=false \
-          tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
-
-
+        echo "🚀 Run terraform apply"
+        ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -auto-approve -input=false tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
 
   - task: AzureCLI@2
     displayName: Clean project

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -88,7 +88,9 @@ steps:
           exit 1
         fi
         
-        echo "🚀 Run terraform apply"
+        cat terraform.sh
+        
+        echo "🚀 Run terraform apply-state"
         ./terraform.sh apply-state ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -auto-approve -input=false tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
 
   - task: AzureCLI@2

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -57,10 +57,10 @@ steps:
 
         if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
           echo "[INFO] 🚀 Run terraform plan + kubernetes -> generate state"
-          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false
+          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -var k8s_kube_config_path_prefix="$(pwd)" -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false -lock-timeout=3000s 
         else
           echo "[INFO] 🚀 Run terraform plan -> generate state"
-          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false
+          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false -lock-timeout=3000s
         fi
 
         echo "✅ State output completed"
@@ -89,7 +89,7 @@ steps:
         fi
         
         echo "🚀 Run terraform apply"
-        ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -auto-approve -input=false tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
+        ./terraform.sh apply-state ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -auto-approve -input=false tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
 
   - task: AzureCLI@2
     displayName: Clean project

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -57,13 +57,13 @@ steps:
 
         echo "before IF"
         if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
-          echo "[INFO] 🚀 Run terraform plan + kubernetes & generate state"
+          echo "[INFO] 🚀 Run terraform plan + kubernetes -> generate state"
           ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
             -lock-timeout=3000s \
             -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} \
             -input=false"
         else
-          echo "[INFO] 🚀 Run terraform plan & generate state"
+          echo "[INFO] 🚀 Run terraform plan -> generate state"
           ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
             -lock-timeout=3000s \
             -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} \

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -29,7 +29,6 @@ parameters:
 
 steps:
   - template: ../azure-kubeconfig-generator/template.yaml
-    condition: and(succeeded(), ne('${{ parameters.AKS_AZURE_DEVOPS_SA_CA_CRT }}', ''))
     parameters:
       AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
       WORKINGDIR: '${{ parameters.WORKINGDIR }}'

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -82,23 +82,19 @@ steps:
         export ARM_CLIENT_SECRET="${servicePrincipalKey}"
         export ARM_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
         export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
-
-        if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
-          echo "[INFO] 🚀 Run terraform plan + kubernetes"
-          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
-            -var k8s_kube_config_path_prefix="$(pwd)" \
-            -lock-timeout=3000s \
-            -auto-approve \
-            -input=false \
-            tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
-        else
-          echo "[INFO] 🚀 Run terraform plan"
-          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
-            -lock-timeout=3000s \
-            -auto-approve \
-            -input=false \
-            tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
+        
+        if ! [[ -e "tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}" ]]; then
+          echo "❌ State file not exist"
+          exit 1
         fi
+        
+        ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
+          -lock-timeout=3000s \
+          -auto-approve \
+          -input=false \
+          tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
+
+
 
   - task: AzureCLI@2
     displayName: Clean project

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -55,6 +55,7 @@ steps:
         export ARM_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
         export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
 
+        echo "before IF"
         if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
           echo "[INFO] 🚀 Run terraform plan + kubernetes & generate state"
           ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} \

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -30,6 +30,7 @@ parameters:
 steps:
   - checkout: self
 
+- ${{ if ne(parameters['AKS_NAME'], '') }}:
   - template: ../azure-kubeconfig-generator/template.yaml
     parameters:
       AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -56,14 +56,8 @@ steps:
         export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
 
         echo "[INFO] before IF"
-#        if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
-#          echo "[INFO] 🚀 Run terraform plan + kubernetes -> generate state"
-#          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false"
-#        else
-#          echo "[INFO] 🚀 Run terraform plan -> generate state"
-#          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false
-#        fi
-        echo "✅ State output generated"
+
+        echo "State output completed"
 
   - task: AzureCLI@2
     displayName: Apply Terraform

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -29,6 +29,7 @@ parameters:
 
 steps:
   - checkout: self
+
   - template: ../azure-kubeconfig-generator/template.yaml
     parameters:
       AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -55,9 +55,15 @@ steps:
         export ARM_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
         export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
 
-        echo "[INFO] before IF"
+        if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
+          echo "[INFO] 🚀 Run terraform plan + kubernetes -> generate state"
+          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false
+        else
+          echo "[INFO] 🚀 Run terraform plan -> generate state"
+          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -out=tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }} -input=false
+        fi
 
-        echo "State output completed"
+        echo "✅ State output completed"
 
   - task: AzureCLI@2
     displayName: Apply Terraform
@@ -79,10 +85,19 @@ steps:
 
         if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
           echo "[INFO] 🚀 Run terraform plan + kubernetes"
-          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} -var k8s_kube_config_path_prefix="$(pwd)" -lock-timeout=3000s -auto-approve -input=false tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
+          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
+            -var k8s_kube_config_path_prefix="$(pwd)" \
+            -lock-timeout=3000s \
+            -auto-approve \
+            -input=false \
+            tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
         else
           echo "[INFO] 🚀 Run terraform plan"
-          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -auto-approve -input=false tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
+          ./terraform.sh apply ${{ parameters.TF_ENVIRONMENT_FOLDER }} \
+            -lock-timeout=3000s \
+            -auto-approve \
+            -input=false \
+            tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
         fi
 
   - task: AzureCLI@2

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -30,7 +30,6 @@ parameters:
 steps:
   - checkout: self
 
-- ${{ if ne(parameters['AKS_NAME'], '') }}:
   - template: ../azure-kubeconfig-generator/template.yaml
     parameters:
       AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'

--- a/templates/terraform-plan-apply/template.yaml
+++ b/templates/terraform-plan-apply/template.yaml
@@ -1,7 +1,7 @@
 # Run terraform init and terraform plan
 parameters:
-  - name: 'DOMAIN_NAME'
-    displayName: '(Required) Domain name.'
+  - name: 'FULL_DOMAIN_NAME'
+    displayName: '(Required) Full Domain name. E.g. rtd_app || rtd_common'
     type: string
   - name: 'AZURE_DEVOPS_POOL_AGENT_NAME'
     displayName: '(Required) Azure devops agent name.'
@@ -39,18 +39,15 @@ parameters:
     type: string
     default: ""
 
-variables:
-  FULL_DOMAIN_SUFFIX_NAME: ${{replace(parameters.DOMAIN_NAME, '-', '_')}}
-
 stages:
-  - stage: ${{parameters.ENVIRONMENT}}_plan_${{variales.FULL_DOMAIN_SUFFIX_NAME}}
-    displayName: 🔦 ${{parameters.ENVIRONMENT}}_plan_${{variales.FULL_DOMAIN_SUFFIX_NAME}}
+  - stage: ${{parameters.ENVIRONMENT}}_plan_${{parameters.FULL_DOMAIN_NAME}}
+    displayName: 🔦 ${{parameters.ENVIRONMENT}}_plan_${{parameters.FULL_DOMAIN_NAME}}
     dependsOn: []
     condition: succeeded()
     pool:
       name: ${{parameters.AZURE_DEVOPS_POOL_AGENT_NAME}}
     jobs:
-      - job: ${{parameters.ENVIRONMENT}}_plan_${{variales.FULL_DOMAIN_SUFFIX_NAME}}
+      - job: ${{parameters.ENVIRONMENT}}_plan_${{parameters.FULL_DOMAIN_NAME}}
         timeoutInMinutes: $[variables.TIME_OUT]
         steps:
           - checkout: self
@@ -67,14 +64,14 @@ stages:
               AKS_AZURE_DEVOPS_SA_CA_CRT: ${{parameters.AKS_AZURE_DEVOPS_SA_CA_CRT}}
               AKS_AZURE_DEVOPS_SA_TOKEN: ${{parameters.AKS_AZURE_DEVOPS_SA_TOKEN}}
 
-  - stage: ${{parameters.ENVIRONMENT}}_apply_${{variales.FULL_DOMAIN_SUFFIX_NAME}}
-    displayName: 🚀 ${{parameters.ENVIRONMENT}}_apply_${{variales.FULL_DOMAIN_SUFFIX_NAME}}
-    dependsOn: ['${{parameters.ENVIRONMENT}}_plan_${{variales.FULL_DOMAIN_SUFFIX_NAME}}']
+  - stage: ${{parameters.ENVIRONMENT}}_apply_${{parameters.FULL_DOMAIN_NAME}}
+    displayName: 🚀 ${{parameters.ENVIRONMENT}}_apply_${{parameters.FULL_DOMAIN_NAME}}
+    dependsOn: ['${{parameters.ENVIRONMENT}}_plan_${{parameters.FULL_DOMAIN_NAME}}']
     condition: succeeded()
     pool:
       name: ${{parameters.AZURE_DEVOPS_POOL_AGENT_NAME}}
     jobs:
-      - deployment: ${{parameters.ENVIRONMENT}}_apply_${{variales.FULL_DOMAIN_SUFFIX_NAME}}
+      - deployment: ${{parameters.ENVIRONMENT}}_apply_${{parameters.FULL_DOMAIN_NAME}}
         continueOnError: false
         environment: ${{parameters.ENVIRONMENT}}
         strategy:

--- a/templates/terraform-plan-apply/template.yaml
+++ b/templates/terraform-plan-apply/template.yaml
@@ -39,15 +39,18 @@ parameters:
     type: string
     default: ""
 
+variables:
+  FULL_DOMAIN_SUFFIX_NAME: ${{replace(parameters.DOMAIN_NAME, '-', '_')}}
+
 stages:
-  - stage: ${{parameters.ENVIRONMENT}}_plan_${{replace(parameters.DOMAIN_NAME, '-', '_')}}
-    displayName: 🔦 ${{parameters.ENVIRONMENT}}_plan_${{parameters.DOMAIN_NAME}}
+  - stage: ${{parameters.ENVIRONMENT}}_plan_${{variales.FULL_DOMAIN_SUFFIX_NAME}}
+    displayName: 🔦 ${{parameters.ENVIRONMENT}}_plan_${{variales.FULL_DOMAIN_SUFFIX_NAME}}
     dependsOn: []
     condition: succeeded()
     pool:
       name: ${{parameters.AZURE_DEVOPS_POOL_AGENT_NAME}}
     jobs:
-      - job: ${{parameters.ENVIRONMENT}}_plan_${{parameters.DOMAIN_NAME}}
+      - job: ${{parameters.ENVIRONMENT}}_plan_${{variales.FULL_DOMAIN_SUFFIX_NAME}}
         timeoutInMinutes: $[variables.TIME_OUT]
         steps:
           - checkout: self
@@ -64,14 +67,14 @@ stages:
               AKS_AZURE_DEVOPS_SA_CA_CRT: ${{parameters.AKS_AZURE_DEVOPS_SA_CA_CRT}}
               AKS_AZURE_DEVOPS_SA_TOKEN: ${{parameters.AKS_AZURE_DEVOPS_SA_TOKEN}}
 
-  - stage: ${{parameters.ENVIRONMENT}}_apply_${{replace(parameters.DOMAIN_NAME, '-', '_')}}
-    displayName: 🚀 ${{parameters.ENVIRONMENT}}_apply_${{parameters.DOMAIN_NAME}}
-    dependsOn: ['${{parameters.ENVIRONMENT}}_plan_${{parameters.DOMAIN_NAME}}']
+  - stage: ${{parameters.ENVIRONMENT}}_apply_${{variales.FULL_DOMAIN_SUFFIX_NAME}}
+    displayName: 🚀 ${{parameters.ENVIRONMENT}}_apply_${{variales.FULL_DOMAIN_SUFFIX_NAME}}
+    dependsOn: ['${{parameters.ENVIRONMENT}}_plan_${{variales.FULL_DOMAIN_SUFFIX_NAME}}']
     condition: succeeded()
     pool:
       name: ${{parameters.AZURE_DEVOPS_POOL_AGENT_NAME}}
     jobs:
-      - deployment: ${{parameters.ENVIRONMENT}}_apply_${{parameters.DOMAIN_NAME}}
+      - deployment: ${{parameters.ENVIRONMENT}}_apply_${{variales.FULL_DOMAIN_SUFFIX_NAME}}
         continueOnError: false
         environment: ${{parameters.ENVIRONMENT}}
         strategy:

--- a/templates/terraform-plan-apply/template.yaml
+++ b/templates/terraform-plan-apply/template.yaml
@@ -40,7 +40,7 @@ parameters:
     default: ""
 
 stages:
-  - stage: ${{parameters.ENVIRONMENT}}_plan_${{parameters.DOMAIN_NAME}}
+  - stage: ${{parameters.ENVIRONMENT}}_plan_${{replace(parameters.DOMAIN_NAME, '-', '_')}}
     displayName: 🔦 ${{parameters.ENVIRONMENT}}_plan_${{parameters.DOMAIN_NAME}}
     dependsOn: []
     condition: succeeded()
@@ -64,7 +64,7 @@ stages:
               AKS_AZURE_DEVOPS_SA_CA_CRT: ${{parameters.AKS_AZURE_DEVOPS_SA_CA_CRT}}
               AKS_AZURE_DEVOPS_SA_TOKEN: ${{parameters.AKS_AZURE_DEVOPS_SA_TOKEN}}
 
-  - stage: ${{parameters.ENVIRONMENT}}_apply_${{parameters.DOMAIN_NAME}}
+  - stage: ${{parameters.ENVIRONMENT}}_apply_${{replace(parameters.DOMAIN_NAME, '-', '_')}}
     displayName: 🚀 ${{parameters.ENVIRONMENT}}_apply_${{parameters.DOMAIN_NAME}}
     dependsOn: ['${{parameters.ENVIRONMENT}}_plan_${{parameters.DOMAIN_NAME}}']
     condition: succeeded()

--- a/templates/terraform-plan-apply/template.yaml
+++ b/templates/terraform-plan-apply/template.yaml
@@ -6,8 +6,11 @@ parameters:
   - name: 'AZURE_DEVOPS_POOL_AGENT_NAME'
     displayName: '(Required) Azure devops agent name.'
     type: string
-  - name: 'AZURE_SERVICE_CONNECTION_NAME'
-    displayName: '(Required) Azure service connection name.'
+  - name: 'AZURE_SERVICE_CONNECTION_PLAN_NAME'
+    displayName: '(Required) Azure service connection name for plan.'
+    type: string
+  - name: 'AZURE_SERVICE_CONNECTION_APPLY_NAME'
+    displayName: '(Required) Azure service connection name for apply.'
     type: string
   - name: 'ENVIRONMENT'
     displayName: '(Required) Azure devops ENV name. For example [dev|uat|prod] etc.'
@@ -55,7 +58,7 @@ stages:
             parameters:
               TF_ENVIRONMENT_FOLDER: ${{parameters.TF_ENVIRONMENT_FOLDER}}
               WORKINGDIR: ${{parameters.WORKINGDIR}}
-              AZURE_SERVICE_CONNECTION_NAME: ${{parameters.AZURE_SERVICE_CONNECTION_NAME}}
+              AZURE_SERVICE_CONNECTION_NAME: ${{parameters.AZURE_SERVICE_CONNECTION_PLAN_NAME}}
               AKS_NAME: ${{parameters.AKS_NAME}}
               AKS_API_SERVER_URL: ${{parameters.AKS_API_SERVER_URL}}
               AKS_AZURE_DEVOPS_SA_CA_CRT: ${{parameters.AKS_AZURE_DEVOPS_SA_CA_CRT}}
@@ -83,7 +86,7 @@ stages:
                   parameters:
                     WORKINGDIR: ${{parameters.WORKINGDIR}}
                     TF_ENVIRONMENT_FOLDER: ${{parameters.TF_ENVIRONMENT_FOLDER}}
-                    AZURE_SERVICE_CONNECTION_NAME: ${{parameters.AZURE_SERVICE_CONNECTION_NAME}}
+                    AZURE_SERVICE_CONNECTION_NAME: ${{parameters.AZURE_SERVICE_CONNECTION_APPLY_NAME}}
                     AKS_NAME: ${{parameters.AKS_NAME}}
                     AKS_API_SERVER_URL: ${{parameters.AKS_API_SERVER_URL}}
                     AKS_AZURE_DEVOPS_SA_CA_CRT: ${{parameters.AKS_AZURE_DEVOPS_SA_CA_CRT}}

--- a/templates/terraform-plan/template.yaml
+++ b/templates/terraform-plan/template.yaml
@@ -28,6 +28,9 @@ parameters:
     default: ""
 
 steps:
+  - checkout: self
+
+- ${{ if ne(parameters['AKS_NAME'], '') }}:
   - template: ../azure-kubeconfig-generator/template.yaml
     parameters:
       AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'

--- a/templates/terraform-plan/template.yaml
+++ b/templates/terraform-plan/template.yaml
@@ -28,7 +28,6 @@ parameters:
     default: ""
 
 steps:
-  - checkout: self
 
   - task: Cache@2
     inputs:

--- a/templates/terraform-plan/template.yaml
+++ b/templates/terraform-plan/template.yaml
@@ -28,44 +28,44 @@ parameters:
     default: ""
 
 steps:
-  - checkout: self
+    - checkout: self
 
-- ${{ if ne(parameters['AKS_NAME'], '') }}:
-  - template: ../azure-kubeconfig-generator/template.yaml
-    parameters:
-      AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
-      WORKINGDIR: '${{ parameters.WORKINGDIR }}'
-      AKS_NAME: '${{ parameters.AKS_NAME }}'
-      AKS_API_SERVER_URL: '${{ parameters.AKS_API_SERVER_URL }}'
-      AKS_AZURE_DEVOPS_SA_CA_CRT: '${{ parameters.AKS_AZURE_DEVOPS_SA_CA_CRT }}'
-      AKS_AZURE_DEVOPS_SA_TOKEN: '${{ parameters.AKS_AZURE_DEVOPS_SA_TOKEN }}'
+  - ${{ if ne(parameters['AKS_NAME'], '') }}:
+    - template: ../azure-kubeconfig-generator/template.yaml
+      parameters:
+        AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
+        WORKINGDIR: '${{ parameters.WORKINGDIR }}'
+        AKS_NAME: '${{ parameters.AKS_NAME }}'
+        AKS_API_SERVER_URL: '${{ parameters.AKS_API_SERVER_URL }}'
+        AKS_AZURE_DEVOPS_SA_CA_CRT: '${{ parameters.AKS_AZURE_DEVOPS_SA_CA_CRT }}'
+        AKS_AZURE_DEVOPS_SA_TOKEN: '${{ parameters.AKS_AZURE_DEVOPS_SA_TOKEN }}'
 
-  - task: AzureCLI@2
-    displayName: Plan Terraform
-    inputs:
-      azureSubscription: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
-      addSpnToEnvironment: true
-      scriptType: 'bash'
-      scriptLocation: 'inlineScript'
-      failOnStandardError: true
-      workingDirectory: '${{ parameters.WORKINGDIR }}'
-      inlineScript: |
-        echo "##[section] 💈 Start terraform plan for tf-env-folder=${{ parameters.TF_ENVIRONMENT_FOLDER }}"
-
-        export ARM_CLIENT_ID="${servicePrincipalId}"
-        export ARM_CLIENT_SECRET="${servicePrincipalKey}"
-        export ARM_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
-        export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
-
-        if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
-          echo "[INFO] 🚀 Run terraform plan + kubernetes"
-          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -var k8s_kube_config_path_prefix="$(pwd)" -lock-timeout=300s -lock=false
-        else
-          echo "[INFO] 🚀 Run terraform plan"
-          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=300s -lock=false
-        fi
-
-        echo "[INFO] Clean project"
-        rm -rf .kube
-        rm -rf .azure
-        rm -rf config-${{ parameters.AKS_NAME }}
+    - task: AzureCLI@2
+      displayName: Plan Terraform
+      inputs:
+        azureSubscription: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
+        addSpnToEnvironment: true
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        failOnStandardError: true
+        workingDirectory: '${{ parameters.WORKINGDIR }}'
+        inlineScript: |
+          echo "##[section] 💈 Start terraform plan for tf-env-folder=${{ parameters.TF_ENVIRONMENT_FOLDER }}"
+  
+          export ARM_CLIENT_ID="${servicePrincipalId}"
+          export ARM_CLIENT_SECRET="${servicePrincipalKey}"
+          export ARM_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
+          export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
+  
+          if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
+            echo "[INFO] 🚀 Run terraform plan + kubernetes"
+            ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -var k8s_kube_config_path_prefix="$(pwd)" -lock-timeout=300s -lock=false
+          else
+            echo "[INFO] 🚀 Run terraform plan"
+            ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=300s -lock=false
+          fi
+  
+          echo "[INFO] Clean project"
+          rm -rf .kube
+          rm -rf .azure
+          rm -rf config-${{ parameters.AKS_NAME }}

--- a/templates/terraform-plan/template.yaml
+++ b/templates/terraform-plan/template.yaml
@@ -29,12 +29,6 @@ parameters:
 
 steps:
 
-  - task: Cache@2
-    inputs:
-      key: 'terraform_plan'
-      path: '${{ parameters.WORKINGDIR }}/.terraform'
-    displayName: Cache .terraform files
-
   - template: ../azure-kubeconfig-generator/template.yaml
     parameters:
       AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'

--- a/templates/terraform-plan/template.yaml
+++ b/templates/terraform-plan/template.yaml
@@ -28,44 +28,43 @@ parameters:
     default: ""
 
 steps:
-    - checkout: self
+  - checkout: self
 
-  - ${{ if ne(parameters['AKS_NAME'], '') }}:
-    - template: ../azure-kubeconfig-generator/template.yaml
-      parameters:
-        AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
-        WORKINGDIR: '${{ parameters.WORKINGDIR }}'
-        AKS_NAME: '${{ parameters.AKS_NAME }}'
-        AKS_API_SERVER_URL: '${{ parameters.AKS_API_SERVER_URL }}'
-        AKS_AZURE_DEVOPS_SA_CA_CRT: '${{ parameters.AKS_AZURE_DEVOPS_SA_CA_CRT }}'
-        AKS_AZURE_DEVOPS_SA_TOKEN: '${{ parameters.AKS_AZURE_DEVOPS_SA_TOKEN }}'
+  - template: ../azure-kubeconfig-generator/template.yaml
+    parameters:
+      AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
+      WORKINGDIR: '${{ parameters.WORKINGDIR }}'
+      AKS_NAME: '${{ parameters.AKS_NAME }}'
+      AKS_API_SERVER_URL: '${{ parameters.AKS_API_SERVER_URL }}'
+      AKS_AZURE_DEVOPS_SA_CA_CRT: '${{ parameters.AKS_AZURE_DEVOPS_SA_CA_CRT }}'
+      AKS_AZURE_DEVOPS_SA_TOKEN: '${{ parameters.AKS_AZURE_DEVOPS_SA_TOKEN }}'
 
-    - task: AzureCLI@2
-      displayName: Plan Terraform
-      inputs:
-        azureSubscription: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
-        addSpnToEnvironment: true
-        scriptType: 'bash'
-        scriptLocation: 'inlineScript'
-        failOnStandardError: true
-        workingDirectory: '${{ parameters.WORKINGDIR }}'
-        inlineScript: |
-          echo "##[section] 💈 Start terraform plan for tf-env-folder=${{ parameters.TF_ENVIRONMENT_FOLDER }}"
-  
-          export ARM_CLIENT_ID="${servicePrincipalId}"
-          export ARM_CLIENT_SECRET="${servicePrincipalKey}"
-          export ARM_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
-          export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
-  
-          if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
-            echo "[INFO] 🚀 Run terraform plan + kubernetes"
-            ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -var k8s_kube_config_path_prefix="$(pwd)" -lock-timeout=300s -lock=false
-          else
-            echo "[INFO] 🚀 Run terraform plan"
-            ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=300s -lock=false
-          fi
-  
-          echo "[INFO] Clean project"
-          rm -rf .kube
-          rm -rf .azure
-          rm -rf config-${{ parameters.AKS_NAME }}
+  - task: AzureCLI@2
+    displayName: Plan Terraform
+    inputs:
+      azureSubscription: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'
+      addSpnToEnvironment: true
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      failOnStandardError: true
+      workingDirectory: '${{ parameters.WORKINGDIR }}'
+      inlineScript: |
+        echo "##[section] 💈 Start terraform plan for tf-env-folder=${{ parameters.TF_ENVIRONMENT_FOLDER }}"
+
+        export ARM_CLIENT_ID="${servicePrincipalId}"
+        export ARM_CLIENT_SECRET="${servicePrincipalKey}"
+        export ARM_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
+        export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
+
+        if [[ "${{ parameters.AKS_NAME }}" != "" ]]; then
+          echo "[INFO] 🚀 Run terraform plan + kubernetes"
+          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -var k8s_kube_config_path_prefix="$(pwd)" -lock-timeout=300s -lock=false
+        else
+          echo "[INFO] 🚀 Run terraform plan"
+          ./terraform.sh plan ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=300s -lock=false
+        fi
+
+        echo "[INFO] Clean project"
+        rm -rf .kube
+        rm -rf .azure
+        rm -rf config-${{ parameters.AKS_NAME }}

--- a/templates/terraform-plan/template.yaml
+++ b/templates/terraform-plan/template.yaml
@@ -30,6 +30,12 @@ parameters:
 steps:
   - checkout: self
 
+  - task: Cache@2
+    inputs:
+      key: '"terraform_plan"'
+      path: */.terraform
+    displayName: Cache .terraform files
+
   - template: ../azure-kubeconfig-generator/template.yaml
     parameters:
       AZURE_SERVICE_CONNECTION_NAME: '${{ parameters.AZURE_SERVICE_CONNECTION_NAME }}'

--- a/templates/terraform-plan/template.yaml
+++ b/templates/terraform-plan/template.yaml
@@ -32,7 +32,7 @@ steps:
   - task: Cache@2
     inputs:
       key: 'terraform_plan'
-      path: '.terraform/'
+      path: '${{ parameters.WORKINGDIR }}/.terraform'
     displayName: Cache .terraform files
 
   - template: ../azure-kubeconfig-generator/template.yaml

--- a/templates/terraform-plan/template.yaml
+++ b/templates/terraform-plan/template.yaml
@@ -32,8 +32,8 @@ steps:
 
   - task: Cache@2
     inputs:
-      key: '"terraform_plan"'
-      path: */.terraform
+      key: 'terraform_plan'
+      path: '.terraform/'
     displayName: Cache .terraform files
 
   - template: ../azure-kubeconfig-generator/template.yaml


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

<!-- markdownlint-disable-next-line -->
### List of changes

- terraform-plan: now don't lock the state, so is more fast and can be cancelled
- terraform-apply: use an internal plan that generate the state output file and allow to apply only the changed. No more locks needed
- azure-kubeconfig-genator: allow to generate the kubeconfig with kubelogin

### Motivation and context

Improve how terraform run in pipelines, in this case is possible to avoid the time related to serial locks and avoid problems for pipelines cancelled that locks the state
### Type of changes

- [x] Add new template
- [x] Update template configuration
- [ ] Remove template
- [ ] Other changes

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
