### PR TITLE
fix: Terraform apply use plain terraform to apply state file

### DIFF
--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -90,9 +90,7 @@ steps:
           exit 1
         fi
         
-        cat terraform.sh
-        
-        echo "🚀 Run terraform apply-state"
+        echo "🚀 Run terraform apply output state"
         terraform apply -lock-timeout=3000s -auto-approve -input=false tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
 
   - task: AzureCLI@2

--- a/templates/terraform-apply/template.yaml
+++ b/templates/terraform-apply/template.yaml
@@ -77,7 +77,7 @@ steps:
       failOnStandardError: true
       workingDirectory: '${{ parameters.WORKINGDIR }}'
       inlineScript: |
-        echo "##[section] 💈 Start terraform apply with tf-env-folder=${{ parameters.TF_ENVIRONMENT_FOLDER }}"
+        echo "##[section] 💈 Start terraform apply with tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}"
 
         echo "[INFO] Terraform setup variables"
         export ARM_CLIENT_ID="${servicePrincipalId}"
@@ -93,7 +93,7 @@ steps:
         cat terraform.sh
         
         echo "🚀 Run terraform apply-state"
-        ./terraform.sh apply-state ${{ parameters.TF_ENVIRONMENT_FOLDER }} -lock-timeout=3000s -auto-approve -input=false tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
+        terraform apply -lock-timeout=3000s -auto-approve -input=false tfplan-${{ parameters.TF_ENVIRONMENT_FOLDER }}
 
   - task: AzureCLI@2
     displayName: Clean project


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

<!-- markdownlint-disable-next-line -->
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

terraform.sh don't need a custom action called `apply-state` but can use a plain terraform apply

### Type of changes

- [ ] Add new template
- [x] Update template configuration
- [ ] Remove template
- [ ] Other changes

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
