### PR TITLE
feat: PAYMCLOUD-379 Add send-mail template using Python SMTP

### DIFF
--- a/templates/send-mail/template.yaml
+++ b/templates/send-mail/template.yaml
@@ -56,7 +56,7 @@ steps:
         # Add body to email
         message.attach(MIMEText(body, "plain"))
         
-        files = "'${{ parameters.ATTACHMENTS_COMMA_SEP }}'".split(",")
+        files = "${{ parameters.ATTACHMENTS_COMMA_SEP }}".split(",")
         
         # Add header as key/value pair to attachment part
         for f in files:  # add files to the message

--- a/templates/send-mail/template.yaml
+++ b/templates/send-mail/template.yaml
@@ -39,9 +39,9 @@ steps:
         from os import getenv
         
         subject = '${{ parameters.MAIL_SUBJECT }}'
-        body = """
-        '${{ parameters.MAIL_BODY }}'
-        """
+        body = '''
+        ${{ parameters.MAIL_BODY }}
+        '''
         sender_email = '${{ parameters.SENDER_EMAIL }}'
         receiver_email = '${{ parameters.RECEIVER_EMAIL }}'
         password = "${{ parameters.APP_PASS }}"
@@ -54,7 +54,7 @@ steps:
         message["Bcc"] = receiver_email
         
         # Add body to email
-        message.attach(MIMEText(body, "plain"))
+        message.attach(MIMEText(body, "html"))
         
         files = "${{ parameters.ATTACHMENTS_COMMA_SEP }}".split(",")
         

--- a/templates/send-mail/template.yaml
+++ b/templates/send-mail/template.yaml
@@ -70,7 +70,6 @@ steps:
             encoders.encode_base64(part)
           
             part.add_header('Content-Disposition','attachment', filename=f)
-            part.attach(attachment)
 
         
         # Add attachment to message and convert message to string

--- a/templates/send-mail/template.yaml
+++ b/templates/send-mail/template.yaml
@@ -42,7 +42,7 @@ steps:
         """
         sender_email = '${{ parameters.SENDER_EMAIL }}'
         receiver_email = '${{ parameters.RECEIVER_EMAIL }}'
-        password = getenv("APP_PASS")
+        password = "'${{ parameters.APP_PASS }}'"
         
         # Create a multipart message and set headers
         message = MIMEMultipart()

--- a/templates/send-mail/template.yaml
+++ b/templates/send-mail/template.yaml
@@ -19,13 +19,15 @@ parameters:
     displayName: '(Optional) Comma separated attachments files name.'
     type: string
     default: ""
+  - name: CONDITION_FLAG
+    displayName: "(Optional) Run on conditions."
+    type: string
+    default: "parameters.succeeded()"
 
 steps:
   - task: PythonScript@0
     name: SendMail
-    env:
-      APP_PASS: $(APP_PASS)
-      KEY_VAULT_CERT_NAME: $(KEY_VAULT_CERT_NAME)
+    condition: '${{ CONDITION_FLAG }}'
     inputs:
       scriptSource: 'inline'
       script: |

--- a/templates/send-mail/template.yaml
+++ b/templates/send-mail/template.yaml
@@ -1,0 +1,82 @@
+# Send mail with a Python smtp client
+parameters:
+  - name: 'MAIL_SUBJECT'
+    displayName: '(Required) Email subject.'
+    type: string
+  - name: 'MAIL_BODY'
+    displayName: '(Required) Email body.'
+    type: string
+  - name: 'RECEIVER_EMAIL'
+    displayName: '(Required) The receiver mail.'
+    type: string
+  - name: 'SENDER_EMAIL'
+    displayName: '(Required) The sender mail.'
+    type: string
+  - name: 'APP_PASS'
+    displayName: '(Required) SMTP App password.'
+    type: string
+  - name: 'ATTACHMENTS_COMMA_SEP'
+    displayName: '(Optional) Comma separated attachments files name.'
+    type: string
+    default: ""
+
+steps:
+  - task: PythonScript@0
+    name: SendMail
+    env:
+      APP_PASS: $(APP_PASS)
+      KEY_VAULT_CERT_NAME: $(KEY_VAULT_CERT_NAME)
+    inputs:
+      scriptSource: 'inline'
+      script: |
+        import email, smtplib, ssl
+        from email import encoders 
+        from email.mime.base import MIMEBase
+        from email.mime.multipart import MIMEMultipart
+        from email.mime.text import MIMEText
+        from os import getenv
+        
+        subject = '${{ parameters.MAIL_SUBJECT }}'
+        body = """
+        '${{ parameters.MAIL_BODY }}'
+        """
+        sender_email = '${{ parameters.SENDER_EMAIL }}'
+        receiver_email = '${{ parameters.RECEIVER_EMAIL }}'
+        password = getenv("APP_PASS")
+        
+        # Create a multipart message and set headers
+        message = MIMEMultipart()
+        message["From"] = sender_email
+        message["To"] = receiver_email
+        message["Subject"] = subject
+        message["Bcc"] = receiver_email
+        
+        # Add body to email
+        message.attach(MIMEText(body, "plain"))
+        
+        files = "'${{ parameters.ATTACHMENTS_COMMA_SEP }}'".split(",")
+        
+        # Add header as key/value pair to attachment part
+        for f in files:  # add files to the message
+          with open(f, "rb") as attachment:
+            # Add file as application/octet-stream
+            # Email client can usually download this automatically as attachment
+            part = MIMEBase("application", "octet-stream")
+            part.set_payload(attachment.read())
+        
+          # Encode file in ASCII characters to send by email    
+          encoders.encode_base64(part)
+        
+          attachment.add_header('Content-Disposition','attachment', filename=f)
+          part.attach(attachment)
+
+        
+        # Add attachment to message and convert message to string
+        message.attach(part)
+        text = message.as_string()
+        
+        # Log in to server using secure context and send email
+        context = ssl.create_default_context()
+        with smtplib.SMTP_SSL("smtp.gmail.com", 465, context=context) as server:
+            server.login(sender_email, password)
+            server.sendmail(sender_email, receiver_email, text)

--- a/templates/send-mail/template.yaml
+++ b/templates/send-mail/template.yaml
@@ -66,11 +66,11 @@ steps:
             part = MIMEBase("application", "octet-stream")
             part.set_payload(attachment.read())
         
-          # Encode file in ASCII characters to send by email    
-          encoders.encode_base64(part)
-        
-          attachment.add_header('Content-Disposition','attachment', filename=f)
-          part.attach(attachment)
+            # Encode file in ASCII characters to send by email    
+            encoders.encode_base64(part)
+          
+            part.add_header('Content-Disposition','attachment', filename=f)
+            part.attach(attachment)
 
         
         # Add attachment to message and convert message to string

--- a/templates/send-mail/template.yaml
+++ b/templates/send-mail/template.yaml
@@ -22,12 +22,12 @@ parameters:
   - name: CONDITION_FLAG
     displayName: "(Optional) Run on conditions."
     type: string
-    default: "parameters.succeeded()"
+    default: "succeeded()"
 
 steps:
   - task: PythonScript@0
     name: SendMail
-    condition: '${{ CONDITION_FLAG }}'
+    condition: '${{ parameters.CONDITION_FLAG }}'
     inputs:
       scriptSource: 'inline'
       script: |

--- a/templates/send-mail/template.yaml
+++ b/templates/send-mail/template.yaml
@@ -44,7 +44,7 @@ steps:
         """
         sender_email = '${{ parameters.SENDER_EMAIL }}'
         receiver_email = '${{ parameters.RECEIVER_EMAIL }}'
-        password = "'${{ parameters.APP_PASS }}'"
+        password = "${{ parameters.APP_PASS }}"
         
         # Create a multipart message and set headers
         message = MIMEMultipart()


### PR DESCRIPTION
### List of changes

- Introduced a new reusable send-mail template utilizing Python's SMTP library.
- Added parameters for email fields (e.g., subject, recipient, etc.), app password, and optional attachments.
- Updated email body handling to use HTML format for better formatting flexibility.
- Fixed string formatting issues for passwords and attachments to enhance reliability.
- Removed redundant and inconsistent code lines for better maintainability.
- Added CONDITION_FLAG parameter to allow controlled execution of the email step in pipelines.
- Replaced password retrieval from environment variables with explicit parameter substitution.

### Motivation and context

This PR introduces a reusable send-mail template to streamline email sending in automation workflows. It resolves formatting issues, enhances reliability, and improves the flexibility of the email sending process with optional attachments, controlled pipeline execution, and cleaner code.

### Type of changes

- [x] Add new template
- [x] Update template configuration
- [ ] Remove template
- [x] Other changes

### Other information

This implementation uses Python's built-in SMTP library for email composition and delivery. It allows customizable email templates and ensures the code is clean and adaptable for various pipeline configurations.