### PR TITLE
fix: Support multiple email recipients in RECEIVER_EMAIL parameter

### DIFF
--- a/templates/send-mail/README.md
+++ b/templates/send-mail/README.md
@@ -11,7 +11,7 @@ This template allows you to send an email using a Python SMTP client, with optio
   _(Required)_ The body of the email, supports HTML content.
 
 - **RECEIVER_EMAIL**  
-  _(Required)_ The recipient's email address.
+  _(Required)_ The recipient's email address, comma separated.
 
 - **SENDER_EMAIL**  
   _(Required)_ The sender's email address.
@@ -70,7 +70,7 @@ Example pipeline parameters:
         </body>
       </html>
     SENDER_EMAIL: "sender@gmail.com"
-    RECEIVER_EMAIL: "recipient@example.com" 
+    RECEIVER_EMAIL: "recipient@example.com,example@example.com" 
     APP_PASS: "APP PASSWORD"
     ATTACHMENTS_COMMA_SEP: "example.pdf"
 ```

--- a/templates/send-mail/template.yaml
+++ b/templates/send-mail/template.yaml
@@ -43,7 +43,7 @@ steps:
         ${{ parameters.MAIL_BODY }}
         '''
         sender_email = '${{ parameters.SENDER_EMAIL }}'
-        receiver_email = '${{ parameters.RECEIVER_EMAIL }}'
+        receiver_email = ${{ parameters.RECEIVER_EMAIL }}.split(",")
         password = "${{ parameters.APP_PASS }}"
         
         # Create a multipart message and set headers


### PR DESCRIPTION
<!-- markdownlint-disable-next-line -->
### List of changes

- Updated the code to allow the `RECEIVER_EMAIL` parameter to support multiple recipients by splitting values with commas.
- Updated the documentation to specify the format for providing multiple recipients.

### Motivation and context

This change ensures that users can send emails to multiple recipients simultaneously, improving functionality and flexibility for batch communication.

### Type of changes

- [ ] Add new template
- [ ] Update template configuration
- [ ] Remove template
- [x] Other changes

### Other information

None.

---

### If PR is partially applied, why? (reserved to mantainers)

None.